### PR TITLE
refactor: break up CSharpTestController god class (SRP)

### DIFF
--- a/src/debug/debugLauncher.ts
+++ b/src/debug/debugLauncher.ts
@@ -1,32 +1,26 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { ChildProcess } from 'child_process';
-import { spawnDotnet, getExtraArgs } from '../utils/dotnetCli';
+import { TestTreeNode } from '../testTreeProvider';
+import { getExtraArgs } from '../utils/dotnetCli';
 import { log, logError, showOutput } from '../utils/outputChannel';
-import { buildFilter, getProjectPath } from '../execution/filterBuilder';
+import { buildFilterForNode } from '../execution/testRunner';
 
 const PID_REGEX = /Process Id:\s*(\d+)/;
 
-export async function debugTests(
-    testRun: vscode.TestRun,
-    items: readonly vscode.TestItem[],
+export async function launchDebugSession(
+    node: TestTreeNode,
     token: vscode.CancellationToken,
 ): Promise<void> {
-    if (items.length === 0) {
+    if (!node.projectPath) {
+        logError('No project path for node');
         return;
     }
 
-    const firstItem = items[0];
-    const projectPath = findProjectPath(firstItem);
-    if (!projectPath) {
-        logError('Cannot debug: no project path found for test item');
-        return;
-    }
+    const projectDir = path.dirname(node.projectPath);
+    const args = ['test', node.projectPath, '--no-restore'];
 
-    const projectDir = path.dirname(projectPath);
-    const { filter } = buildFilter(items);
-
-    const args = ['test', projectPath, '--no-restore'];
+    const filter = buildFilterForNode(node);
     if (filter) {
         args.push('--filter', filter);
     }
@@ -36,18 +30,14 @@ export async function debugTests(
         args.push(...extraArgs);
     }
 
-    log('Starting test host in debug mode (VSTEST_HOST_DEBUG=1)...');
+    log('Starting test host with VSTEST_HOST_DEBUG=1...');
     showOutput();
 
+    const { spawnDotnet } = await import('../utils/dotnetCli');
     const proc = spawnDotnet(args, projectDir, { VSTEST_HOST_DEBUG: '1' });
 
     try {
         const pid = await waitForPid(proc, token);
-
-        if (token.isCancellationRequested) {
-            proc.kill();
-            return;
-        }
 
         log(`Test host PID: ${pid}. Attaching debugger...`);
 
@@ -58,18 +48,15 @@ export async function debugTests(
             processId: pid.toString(),
         };
 
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        const started = await vscode.debug.startDebugging(workspaceFolder, debugConfig);
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        const started = await vscode.debug.startDebugging(folder, debugConfig);
 
         if (!started) {
-            logError(
-                'Failed to attach debugger. Make sure the C# extension (or OmniSharp) is installed.',
-            );
+            logError('Failed to attach debugger');
             proc.kill();
             return;
         }
 
-        // Wait for the process to exit
         await new Promise<void>((resolve) => {
             proc.on('close', () => resolve());
             token.onCancellationRequested(() => {
@@ -81,8 +68,8 @@ export async function debugTests(
         log('Debug session completed.');
     } catch (err) {
         proc.kill();
-        if (err instanceof Error && err.message !== 'Cancelled') {
-            logError('Debug session failed', err);
+        if (!(err instanceof Error && err.message === 'Cancelled')) {
+            logError('Debug failed', err);
         }
     }
 }
@@ -95,9 +82,8 @@ function waitForPid(proc: ChildProcess, token: vscode.CancellationToken): Promis
             buffer += data.toString();
             const match = buffer.match(PID_REGEX);
             if (match) {
-                const pid = parseInt(match[1], 10);
                 proc.stdout?.removeListener('data', onData);
-                resolve(pid);
+                resolve(parseInt(match[1], 10));
             }
         };
 
@@ -107,31 +93,14 @@ function waitForPid(proc: ChildProcess, token: vscode.CancellationToken): Promis
         });
 
         proc.on('close', (code) => {
-            reject(new Error(`Test host exited (code ${code}) before PID was detected`));
+            reject(new Error(`Test host exited (code ${code}) before PID detected`));
         });
 
-        const onCancel = token.onCancellationRequested(() => {
-            onCancel.dispose();
+        token.onCancellationRequested(() => {
+            proc.kill();
             reject(new Error('Cancelled'));
         });
 
-        // Timeout after 60 seconds
-        setTimeout(() => {
-            reject(
-                new Error('Timed out waiting for test host PID. Is VSTEST_HOST_DEBUG supported?'),
-            );
-        }, 60_000);
+        setTimeout(() => reject(new Error('Timeout waiting for test host PID')), 60_000);
     });
-}
-
-function findProjectPath(item: vscode.TestItem): string | undefined {
-    let current: vscode.TestItem | undefined = item;
-    while (current) {
-        const pp = getProjectPath(current);
-        if (pp) {
-            return pp;
-        }
-        current = current.parent;
-    }
-    return undefined;
 }

--- a/src/execution/resultMatcher.ts
+++ b/src/execution/resultMatcher.ts
@@ -1,0 +1,145 @@
+import { TestTreeProvider, TestTreeNode, TestState } from '../testTreeProvider';
+import { TrxSummary } from './trxParser';
+import { log } from '../utils/outputChannel';
+
+export interface ResultDetails {
+    errorMessage?: string;
+    stackTrace?: string;
+    duration?: number;
+}
+
+/**
+ * Normalizes parameter formatting in test names for comparison.
+ * TRX output and source-code discovery may differ in whitespace within parameter lists
+ * (e.g., "Method(1, 2)" vs "Method(1,2)").
+ */
+export function normalizeTestName(name: string): string {
+    const parenIdx = name.indexOf('(');
+    if (parenIdx === -1) {
+        return name;
+    }
+    return name.substring(0, parenIdx) + name.substring(parenIdx).replace(/,\s+/g, ',');
+}
+
+export function applyResultState(
+    node: TestTreeNode,
+    state: TestState,
+    details: ResultDetails | undefined,
+    treeProvider: TestTreeProvider,
+): void {
+    node.state = state;
+    if (details) {
+        node.errorMessage = details.errorMessage;
+        node.stackTrace = details.stackTrace;
+        node.duration = details.duration;
+    }
+    treeProvider.refreshNode(node);
+}
+
+/**
+ * Matches TRX results to tree nodes using a multi-pass strategy:
+ * 1. Exact FQN match (normalized for whitespace differences)
+ * 2. Dynamic parameterized case node creation for unmatched parameterized results
+ * 3. Base name match (stripping parameters)
+ * 4. Short name fallback (last segment of FQN)
+ */
+export function matchAndApplyResults(
+    summary: TrxSummary,
+    methodNodes: TestTreeNode[],
+    treeProvider: TestTreeProvider,
+): void {
+    const methodsByName = new Map<string, TestTreeNode[]>();
+    for (const m of methodNodes) {
+        const shortName =
+            m.fqn
+                .replace(/\(.*\)$/, '')
+                .split('.')
+                .pop() ?? m.fqn;
+        const list = methodsByName.get(shortName) ?? [];
+        list.push(m);
+        methodsByName.set(shortName, list);
+    }
+
+    for (const tr of summary.results) {
+        const state: TestState =
+            tr.outcome === 'Passed'
+                ? 'passed'
+                : tr.outcome === 'Failed' ||
+                    tr.outcome === 'Error' ||
+                    tr.outcome === 'Timeout'
+                  ? 'failed'
+                  : 'skipped';
+
+        const details: ResultDetails = {
+            errorMessage: tr.errorMessage,
+            stackTrace: tr.stackTrace,
+            duration: tr.duration,
+        };
+
+        let matched = tryMatchResult(tr.testName, state, details, methodNodes, treeProvider);
+
+        if (!matched) {
+            const baseName = tr.testName.replace(/\(.*\)$/, '');
+            const hasParams = baseName !== tr.testName;
+
+            if (hasParams) {
+                const parentBaseFqn = baseName;
+                const displayName = tr.testName.split('.').pop() ?? tr.testName;
+                const dynamicNode = treeProvider.addDynamicCaseNode(
+                    parentBaseFqn,
+                    tr.testName,
+                    displayName,
+                );
+                if (dynamicNode) {
+                    applyResultState(dynamicNode, state, details, treeProvider);
+                    matched = true;
+                }
+            }
+
+            if (!matched) {
+                matched = tryMatchResult(baseName, state, details, methodNodes, treeProvider);
+            }
+        }
+
+        if (!matched) {
+            const shortName =
+                tr.testName
+                    .replace(/\(.*\)$/, '')
+                    .split('.')
+                    .pop() ?? tr.testName;
+            const candidates = methodsByName.get(shortName);
+            if (candidates && candidates.length > 0) {
+                for (const c of candidates) {
+                    applyResultState(c, state, details, treeProvider);
+                }
+                matched = true;
+            }
+        }
+
+        if (!matched) {
+            log(`Unmatched result: ${tr.testName} (${tr.outcome})`);
+        }
+    }
+
+    log(
+        `Results: ${summary.passed} passed, ${summary.failed} failed, ${summary.skipped} skipped`,
+    );
+}
+
+function tryMatchResult(
+    name: string,
+    state: TestState,
+    details: ResultDetails,
+    candidates: TestTreeNode[],
+    treeProvider: TestTreeProvider,
+): boolean {
+    const normalized = normalizeTestName(name);
+    for (const node of candidates) {
+        const normalizedFqn = normalizeTestName(node.fqn);
+        if (normalizedFqn === normalized || normalizedFqn.endsWith(`.${normalized}`)) {
+            applyResultState(node, state, details, treeProvider);
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/execution/testRunner.ts
+++ b/src/execution/testRunner.ts
@@ -2,59 +2,80 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import * as os from 'os';
+import { TestTreeProvider, TestTreeNode } from '../testTreeProvider';
 import { runDotnet, getExtraArgs } from '../utils/dotnetCli';
-import { log, logError, showOutput } from '../utils/outputChannel';
-import { parseTrxFile, TrxSummary, TestResult } from './trxParser';
-import { buildFilter, getProjectPath } from './filterBuilder';
+import { parseTrxFile } from './trxParser';
+import { log, logError } from '../utils/outputChannel';
+import { matchAndApplyResults, applyResultState } from './resultMatcher';
 
 const RESULTS_DIR_NAME = '.cursor-test-results';
 
-export interface RunResult {
-    trxSummary: TrxSummary;
-    projectPath: string;
+export function buildFilterForNode(node: TestTreeNode): string | undefined {
+    switch (node.nodeType) {
+        case 'parameterizedCase':
+            return `FullyQualifiedName=${node.fqn}`;
+        case 'method':
+            return `FullyQualifiedName~${node.fqn.split('.').pop()}`;
+        case 'class':
+            return `FullyQualifiedName~${node.fqn}`;
+        case 'namespace':
+            return `FullyQualifiedName~${node.fqn}`;
+        case 'project':
+            return undefined;
+    }
 }
 
-export async function runTests(
-    testRun: vscode.TestRun,
-    items: readonly vscode.TestItem[],
-    token: vscode.CancellationToken,
-): Promise<RunResult | undefined> {
-    // Group items by project
-    const projectGroups = groupByProject(items);
+export function collectMethodNodes(node: TestTreeNode): TestTreeNode[] {
+    if (node.nodeType === 'parameterizedCase') {
+        return [node];
+    }
+    if (node.nodeType === 'method' && node.children.length === 0) {
+        return [node];
+    }
+    const result: TestTreeNode[] = [];
+    for (const child of node.children) {
+        result.push(...collectMethodNodes(child));
+    }
+    return result;
+}
 
-    for (const [projectPath, projectItems] of projectGroups) {
-        if (token.isCancellationRequested) {
-            return undefined;
-        }
-
-        const result = await runProjectTests(testRun, projectPath, projectItems, token);
-        if (result) {
-            applyResults(testRun, projectItems, result.trxSummary);
-            return result;
+export function markRunningNodesAsFailed(
+    node: TestTreeNode,
+    err: unknown,
+    treeProvider: TestTreeProvider,
+): void {
+    const methodNodes = collectMethodNodes(node);
+    for (const m of methodNodes) {
+        if (m.state === 'running') {
+            applyResultState(
+                m,
+                'failed',
+                { errorMessage: err instanceof Error ? err.message : String(err) },
+                treeProvider,
+            );
         }
     }
-
-    return undefined;
 }
 
-async function runProjectTests(
-    testRun: vscode.TestRun,
-    projectPath: string,
-    items: vscode.TestItem[],
+export async function executeTests(
+    node: TestTreeNode,
     token: vscode.CancellationToken,
-): Promise<RunResult | undefined> {
-    const projectDir = path.dirname(projectPath);
+    treeProvider: TestTreeProvider,
+): Promise<void> {
+    if (!node.projectPath || token.isCancellationRequested) {
+        return;
+    }
 
+    const projectDir = path.dirname(node.projectPath);
     const trxDir = path.join(os.tmpdir(), RESULTS_DIR_NAME, Date.now().toString());
     await fs.mkdir(trxDir, { recursive: true });
     const trxFileName = 'results.trx';
 
-    const { filter } = buildFilter(items);
-
-    const args = ['test', projectPath, '--no-restore'];
+    const args = ['test', node.projectPath, '--no-restore'];
     args.push('--logger', `trx;LogFileName=${trxFileName}`);
     args.push('--results-directory', trxDir);
 
+    const filter = buildFilterForNode(node);
     if (filter) {
         args.push('--filter', filter);
     }
@@ -64,161 +85,56 @@ async function runProjectTests(
         args.push(...extraArgs);
     }
 
-    // Mark all included test items as started
-    for (const item of items) {
-        markStarted(testRun, item);
-    }
-
+    let result: Awaited<ReturnType<typeof runDotnet>>;
     try {
-        const result = await runDotnet(args, projectDir, token);
-
-        if (token.isCancellationRequested) {
-            return undefined;
-        }
-
-        testRun.appendOutput(result.stdout.replace(/\n/g, '\r\n'));
-
-        if (result.stderr) {
-            testRun.appendOutput(`\r\n--- stderr ---\r\n${result.stderr.replace(/\n/g, '\r\n')}`);
-        }
-
-        const trxPath = path.join(trxDir, trxFileName);
-        let trxSummary: TrxSummary;
-
-        try {
-            trxSummary = await parseTrxFile(trxPath);
-        } catch {
-            logError('TRX file not found or unreadable, falling back to exit code');
-            trxSummary = {
-                total: 0,
-                passed: 0,
-                failed: 0,
-                skipped: 0,
-                duration: 0,
-                results: [],
-            };
-
-            if (result.exitCode !== 0) {
-                for (const item of items) {
-                    markFailed(testRun, item, 'Test run failed. Check output for details.');
-                }
-            }
-        }
-
-        // Clean up temp directory (best-effort)
-        fs.rm(trxDir, { recursive: true }).catch(() => {});
-
-        return { trxSummary, projectPath };
+        result = await runDotnet(args, projectDir, token);
     } catch (err) {
-        if (err instanceof Error && err.message === 'Cancelled') {
-            return undefined;
+        if (isCancelError(err)) {
+            throw err;
         }
-        logError('Test run failed', err);
-        showOutput();
-        return undefined;
-    }
-}
 
-function applyResults(
-    testRun: vscode.TestRun,
-    items: vscode.TestItem[],
-    summary: TrxSummary,
-): void {
-    // Build a map from test name -> result for quick lookup
-    const resultMap = new Map<string, TestResult>();
-    for (const r of summary.results) {
-        resultMap.set(r.testName, r);
-    }
-
-    for (const item of items) {
-        applyResultToItem(testRun, item, resultMap);
-    }
-
-    log(
-        `Run complete: ${summary.passed} passed, ${summary.failed} failed, ${summary.skipped} skipped (${summary.duration}ms)`,
-    );
-}
-
-function applyResultToItem(
-    testRun: vscode.TestRun,
-    item: vscode.TestItem,
-    resultMap: Map<string, TestResult>,
-): void {
-    // Check if this item has a direct result
-    const result = resultMap.get(item.id) ?? resultMap.get(item.label);
-
-    if (result) {
-        const duration = result.duration;
-        switch (result.outcome) {
-            case 'Passed':
-                testRun.passed(item, duration);
-                break;
-            case 'Failed':
-            case 'Error':
-            case 'Timeout':
-                markFailed(testRun, item, result.errorMessage, result.stackTrace, duration);
-                break;
-            case 'NotExecuted':
-            case 'Inconclusive':
-                testRun.skipped(item);
-                break;
-        }
+        logError(`dotnet test failed to execute for ${node.label}`, err);
+        markRunningNodesAsFailed(node, err, treeProvider);
+        fs.rm(trxDir, { recursive: true }).catch(() => {});
         return;
     }
 
-    // Recurse into children
-    item.children.forEach((child) => {
-        applyResultToItem(testRun, child, resultMap);
-    });
-}
-
-function groupByProject(items: readonly vscode.TestItem[]): Map<string, vscode.TestItem[]> {
-    const groups = new Map<string, vscode.TestItem[]>();
-
-    for (const item of items) {
-        const pp = findProjectPath(item);
-        if (!pp) {
-            continue;
-        }
-
-        let list = groups.get(pp);
-        if (!list) {
-            list = [];
-            groups.set(pp, list);
-        }
-        list.push(item);
+    if (token.isCancellationRequested) {
+        return;
     }
 
-    return groups;
-}
+    const trxPath = path.join(trxDir, trxFileName);
+    const methodNodes = collectMethodNodes(node);
 
-function findProjectPath(item: vscode.TestItem): string | undefined {
-    let current: vscode.TestItem | undefined = item;
-    while (current) {
-        const pp = getProjectPath(current);
-        if (pp) {
-            return pp;
+    try {
+        const summary = await parseTrxFile(trxPath);
+        matchAndApplyResults(summary, methodNodes, treeProvider);
+    } catch {
+        logError('Could not read TRX results, check output for raw dotnet test output');
+        if (result.stdout) {
+            log(result.stdout);
         }
-        current = current.parent;
+        if (result.stderr) {
+            log(result.stderr);
+        }
+
+        if (result.exitCode !== 0) {
+            for (const m of methodNodes) {
+                if (m.state === 'running') {
+                    applyResultState(
+                        m,
+                        'failed',
+                        { errorMessage: 'Test run failed. Check C# Test Explorer output.' },
+                        treeProvider,
+                    );
+                }
+            }
+        }
     }
-    return undefined;
+
+    fs.rm(trxDir, { recursive: true }).catch(() => {});
 }
 
-function markStarted(testRun: vscode.TestRun, item: vscode.TestItem): void {
-    testRun.started(item);
-    item.children.forEach((child) => markStarted(testRun, child));
-}
-
-function markFailed(
-    testRun: vscode.TestRun,
-    item: vscode.TestItem,
-    message?: string,
-    stackTrace?: string,
-    duration?: number,
-): void {
-    const msg = new vscode.TestMessage(message ?? 'Test failed');
-    if (stackTrace) {
-        msg.message = `${message ?? 'Test failed'}\n\n${stackTrace}`;
-    }
-    testRun.failed(item, msg, duration);
+function isCancelError(err: unknown): boolean {
+    return err instanceof Error && err.message === 'Cancelled';
 }

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -1,30 +1,21 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
-import * as os from 'os';
-import * as fs from 'fs/promises';
 import { detectTestProjects, TestProject } from './discovery/projectDetector';
 import { discoverTests, DiscoveredTest } from './discovery/dotnetDiscoverer';
-import { TestTreeProvider, TestTreeNode, TestState } from './testTreeProvider';
-import { runDotnet, getExtraArgs } from './utils/dotnetCli';
-import { parseTrxFile } from './execution/trxParser';
+import { TestTreeProvider, TestTreeNode } from './testTreeProvider';
+import { StatusBarManager } from './ui/statusBarManager';
+import {
+    executeTests,
+    collectMethodNodes,
+    markRunningNodesAsFailed,
+} from './execution/testRunner';
+import { launchDebugSession } from './debug/debugLauncher';
 import { log, logError, showOutput } from './utils/outputChannel';
 
-/**
- * Normalizes parameter formatting in test names for comparison.
- * TRX output and source-code discovery may differ in whitespace within parameter lists
- * (e.g., "Method(1, 2)" vs "Method(1,2)").
- */
-export function normalizeTestName(name: string): string {
-    const parenIdx = name.indexOf('(');
-    if (parenIdx === -1) {
-        return name;
-    }
-    return name.substring(0, parenIdx) + name.substring(parenIdx).replace(/,\s+/g, ',');
-}
+export { normalizeTestName } from './execution/resultMatcher';
 
 export class CSharpTestController implements vscode.Disposable {
     readonly treeProvider: TestTreeProvider;
-    private readonly statusBar: vscode.StatusBarItem;
+    private readonly statusBar: StatusBarManager;
     private readonly disposables: vscode.Disposable[] = [];
     private isDiscovering = false;
 
@@ -36,16 +27,12 @@ export class CSharpTestController implements vscode.Disposable {
 
     constructor(private readonly context: vscode.ExtensionContext) {
         this.treeProvider = new TestTreeProvider();
+        this.statusBar = new StatusBarManager();
 
         const treeView = vscode.window.createTreeView('csharpTestExplorerView', {
             treeDataProvider: this.treeProvider,
             showCollapseAll: true,
         });
-
-        this.statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
-        this.statusBar.command = 'csharpTestExplorer.runAll';
-        this.statusBar.text = '$(beaker) C# Tests';
-        this.statusBar.show();
 
         this.disposables.push(treeView, this.statusBar, this.treeProvider);
     }
@@ -62,9 +49,8 @@ export class CSharpTestController implements vscode.Disposable {
             this.activeCts = undefined;
             this.isRunning = false;
 
-            // Clear all "running" states back to "none"
             this.treeProvider.clearRunningStates();
-            this.updateStatusBar();
+            this.statusBar.updateResults(this.treeProvider.getAllMethodNodes());
             log('Test run cancelled.');
         }
     }
@@ -76,14 +62,14 @@ export class CSharpTestController implements vscode.Disposable {
         }
 
         this.isDiscovering = true;
-        this.statusBar.text = '$(loading~spin) Discovering C# tests...';
+        this.statusBar.showDiscovering();
 
         try {
             this.projects = await detectTestProjects();
 
             if (this.projects.length === 0) {
                 log('No test projects found.');
-                this.statusBar.text = '$(beaker) No test projects';
+                this.statusBar.showNoProjects();
                 return;
             }
 
@@ -102,13 +88,13 @@ export class CSharpTestController implements vscode.Disposable {
 
             this.treeProvider.buildTree(this.projects, this.testsByProject);
 
-            this.statusBar.text = `$(beaker) ${totalTests} C# test(s)`;
+            this.statusBar.showDiscovered(totalTests);
             log(
                 `Discovery complete: ${totalTests} test(s) across ${this.projects.length} project(s).`,
             );
         } catch (err) {
             logError('Discovery failed', err);
-            this.statusBar.text = '$(error) Discovery failed';
+            this.statusBar.showDiscoveryFailed();
         } finally {
             this.isDiscovering = false;
         }
@@ -121,18 +107,18 @@ export class CSharpTestController implements vscode.Disposable {
         }
 
         this.startRun();
-        const methodNodes = this.collectMethodNodes(node);
+        const methodNodes = collectMethodNodes(node);
         for (const m of methodNodes) {
             m.state = 'running';
         }
         this.treeProvider.refresh();
 
         try {
-            await this.executeTests(node, this.activeCts!.token);
+            await executeTests(node, this.activeCts!.token, this.treeProvider);
         } catch (err) {
             if (!this.isCancelError(err)) {
                 logError('Run failed', err);
-                this.markRunningNodesAsFailed(node, err);
+                markRunningNodesAsFailed(node, err, this.treeProvider);
             }
         } finally {
             this.finishRun();
@@ -155,14 +141,14 @@ export class CSharpTestController implements vscode.Disposable {
                 }
 
                 try {
-                    await this.executeTests(root, token);
+                    await executeTests(root, token, this.treeProvider);
                 } catch (err) {
                     if (this.isCancelError(err)) {
                         break;
                     }
 
                     logError(`Run failed for project: ${root.label}`, err);
-                    this.markRunningNodesAsFailed(root, err);
+                    markRunningNodesAsFailed(root, err, this.treeProvider);
                 }
             }
         } finally {
@@ -177,82 +163,12 @@ export class CSharpTestController implements vscode.Disposable {
         }
 
         this.startRun();
-        this.statusBar.text = '$(debug) Debugging...';
+        this.statusBar.showDebugging();
         showOutput();
 
-        const projectDir = path.dirname(node.projectPath);
-        const args = ['test', node.projectPath, '--no-restore'];
-
-        const filter = this.buildFilterForNode(node);
-        if (filter) {
-            args.push('--filter', filter);
-        }
-
-        const extraArgs = getExtraArgs();
-        if (extraArgs.length > 0) {
-            args.push(...extraArgs);
-        }
-
-        log('Starting test host with VSTEST_HOST_DEBUG=1...');
-
-        const { spawnDotnet } = await import('./utils/dotnetCli');
-        const proc = spawnDotnet(args, projectDir, { VSTEST_HOST_DEBUG: '1' });
-
-        const pidRegex = /Process Id:\s*(\d+)/;
-        let buffer = '';
-        const token = this.activeCts!.token;
-
         try {
-            const pid = await new Promise<number>((resolve, reject) => {
-                proc.stdout?.on('data', (data: Buffer) => {
-                    buffer += data.toString();
-                    const match = buffer.match(pidRegex);
-                    if (match) {
-                        resolve(parseInt(match[1], 10));
-                    }
-                });
-                proc.stderr?.on('data', (data: Buffer) => {
-                    buffer += data.toString();
-                });
-                proc.on('close', (code) => {
-                    reject(new Error(`Test host exited (code ${code}) before PID detected`));
-                });
-                token.onCancellationRequested(() => {
-                    proc.kill();
-                    reject(new Error('Cancelled'));
-                });
-                setTimeout(() => reject(new Error('Timeout waiting for test host PID')), 60_000);
-            });
-
-            log(`Test host PID: ${pid}. Attaching debugger...`);
-
-            const debugConfig: vscode.DebugConfiguration = {
-                type: 'coreclr',
-                name: 'Attach to Test Host',
-                request: 'attach',
-                processId: pid.toString(),
-            };
-
-            const folder = vscode.workspace.workspaceFolders?.[0];
-            const started = await vscode.debug.startDebugging(folder, debugConfig);
-
-            if (!started) {
-                logError('Failed to attach debugger');
-                proc.kill();
-                return;
-            }
-
-            await new Promise<void>((resolve) => {
-                proc.on('close', () => resolve());
-                token.onCancellationRequested(() => {
-                    proc.kill();
-                    resolve();
-                });
-            });
-
-            log('Debug session completed.');
+            await launchDebugSession(node, this.activeCts!.token);
         } catch (err) {
-            proc.kill();
             if (!this.isCancelError(err)) {
                 logError('Debug failed', err);
             }
@@ -262,12 +178,10 @@ export class CSharpTestController implements vscode.Disposable {
     }
 
     private startRun(): void {
-        // Cancel any existing run
         this.stopRun();
         this.activeCts = new vscode.CancellationTokenSource();
         this.isRunning = true;
-        this.statusBar.text = '$(loading~spin) Running tests...';
-        // Update context for when-clause so stop button appears
+        this.statusBar.showRunning();
         vscode.commands.executeCommand('setContext', 'csharpTestExplorer.isRunning', true);
     }
 
@@ -277,252 +191,12 @@ export class CSharpTestController implements vscode.Disposable {
         this.activeCts = undefined;
         vscode.commands.executeCommand('setContext', 'csharpTestExplorer.isRunning', false);
 
-        // Clear any nodes still stuck in "running"
         this.treeProvider.clearRunningStates();
-        this.updateStatusBar();
-    }
-
-    private async executeTests(node: TestTreeNode, token: vscode.CancellationToken): Promise<void> {
-        if (!node.projectPath || token.isCancellationRequested) {
-            return;
-        }
-
-        const projectDir = path.dirname(node.projectPath);
-        const trxDir = path.join(os.tmpdir(), '.cursor-test-results', Date.now().toString());
-        await fs.mkdir(trxDir, { recursive: true });
-        const trxFileName = 'results.trx';
-
-        const args = ['test', node.projectPath, '--no-restore'];
-        args.push('--logger', `trx;LogFileName=${trxFileName}`);
-        args.push('--results-directory', trxDir);
-
-        const filter = this.buildFilterForNode(node);
-        if (filter) {
-            args.push('--filter', filter);
-        }
-
-        const extraArgs = getExtraArgs();
-        if (extraArgs.length > 0) {
-            args.push(...extraArgs);
-        }
-
-        let result: Awaited<ReturnType<typeof runDotnet>>;
-        try {
-            result = await runDotnet(args, projectDir, token);
-        } catch (err) {
-            if (this.isCancelError(err)) {
-                throw err;
-            }
-
-            logError(`dotnet test failed to execute for ${node.label}`, err);
-            this.markRunningNodesAsFailed(node, err);
-            fs.rm(trxDir, { recursive: true }).catch(() => {});
-            return;
-        }
-
-        if (token.isCancellationRequested) {
-            return;
-        }
-
-        const trxPath = path.join(trxDir, trxFileName);
-        const methodNodes = this.collectMethodNodes(node);
-
-        try {
-            const summary = await parseTrxFile(trxPath);
-
-            // Build lookup maps for flexible matching (strip params so parameterized cases group by base method name)
-            const methodsByName = new Map<string, TestTreeNode[]>();
-            for (const m of methodNodes) {
-                const shortName =
-                    m.fqn
-                        .replace(/\(.*\)$/, '')
-                        .split('.')
-                        .pop() ?? m.fqn;
-                const list = methodsByName.get(shortName) ?? [];
-                list.push(m);
-                methodsByName.set(shortName, list);
-            }
-
-            for (const tr of summary.results) {
-                const state: TestState =
-                    tr.outcome === 'Passed'
-                        ? 'passed'
-                        : tr.outcome === 'Failed' ||
-                            tr.outcome === 'Error' ||
-                            tr.outcome === 'Timeout'
-                          ? 'failed'
-                          : 'skipped';
-
-                const details = {
-                    errorMessage: tr.errorMessage,
-                    stackTrace: tr.stackTrace,
-                    duration: tr.duration,
-                };
-
-                // Try exact FQN match (works for parameterized cases discovered statically)
-                let matched = this.tryMatchResult(tr.testName, state, details, methodNodes);
-
-                if (!matched) {
-                    const baseName = tr.testName.replace(/\(.*\)$/, '');
-                    const hasParams = baseName !== tr.testName;
-
-                    if (hasParams) {
-                        // Dynamically create a parameterized case node under the parent method
-                        const parentBaseFqn = baseName;
-                        const displayName = tr.testName.split('.').pop() ?? tr.testName;
-                        const dynamicNode = this.treeProvider.addDynamicCaseNode(
-                            parentBaseFqn,
-                            tr.testName,
-                            displayName,
-                        );
-                        if (dynamicNode) {
-                            this.applyState(dynamicNode, state, details);
-                            matched = true;
-                        }
-                    }
-
-                    if (!matched) {
-                        matched = this.tryMatchResult(baseName, state, details, methodNodes);
-                    }
-                }
-
-                if (!matched) {
-                    const shortName =
-                        tr.testName
-                            .replace(/\(.*\)$/, '')
-                            .split('.')
-                            .pop() ?? tr.testName;
-                    const candidates = methodsByName.get(shortName);
-                    if (candidates && candidates.length > 0) {
-                        for (const c of candidates) {
-                            this.applyState(c, state, details);
-                        }
-                        matched = true;
-                    }
-                }
-
-                if (!matched) {
-                    log(`Unmatched result: ${tr.testName} (${tr.outcome})`);
-                }
-            }
-
-            log(
-                `Results: ${summary.passed} passed, ${summary.failed} failed, ${summary.skipped} skipped`,
-            );
-        } catch {
-            logError('Could not read TRX results, check output for raw dotnet test output');
-            if (result.stdout) {
-                log(result.stdout);
-            }
-            if (result.stderr) {
-                log(result.stderr);
-            }
-
-            if (result.exitCode !== 0) {
-                for (const m of methodNodes) {
-                    if (m.state === 'running') {
-                        this.applyState(m, 'failed', {
-                            errorMessage: 'Test run failed. Check C# Test Explorer output.',
-                        });
-                    }
-                }
-            }
-        }
-
-        fs.rm(trxDir, { recursive: true }).catch(() => {});
-    }
-
-    private tryMatchResult(
-        name: string,
-        state: TestState,
-        details: { errorMessage?: string; stackTrace?: string; duration?: number },
-        candidates: TestTreeNode[],
-    ): boolean {
-        const normalized = normalizeTestName(name);
-        for (const node of candidates) {
-            const normalizedFqn = normalizeTestName(node.fqn);
-            if (normalizedFqn === normalized || normalizedFqn.endsWith(`.${normalized}`)) {
-                this.applyState(node, state, details);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private applyState(
-        node: TestTreeNode,
-        state: TestState,
-        details?: { errorMessage?: string; stackTrace?: string; duration?: number },
-    ): void {
-        node.state = state;
-        if (details) {
-            node.errorMessage = details.errorMessage;
-            node.stackTrace = details.stackTrace;
-            node.duration = details.duration;
-        }
-        this.treeProvider.refreshNode(node);
-    }
-
-    private buildFilterForNode(node: TestTreeNode): string | undefined {
-        switch (node.nodeType) {
-            case 'parameterizedCase':
-                return `FullyQualifiedName=${node.fqn}`;
-            case 'method':
-                return `FullyQualifiedName~${node.fqn.split('.').pop()}`;
-            case 'class':
-                return `FullyQualifiedName~${node.fqn}`;
-            case 'namespace':
-                return `FullyQualifiedName~${node.fqn}`;
-            case 'project':
-                return undefined;
-        }
-    }
-
-    private markRunningNodesAsFailed(node: TestTreeNode, err: unknown): void {
-        const methodNodes = this.collectMethodNodes(node);
-        for (const m of methodNodes) {
-            if (m.state === 'running') {
-                this.applyState(m, 'failed', {
-                    errorMessage: err instanceof Error ? err.message : String(err),
-                });
-            }
-        }
-    }
-
-    private collectMethodNodes(node: TestTreeNode): TestTreeNode[] {
-        if (node.nodeType === 'parameterizedCase') {
-            return [node];
-        }
-        if (node.nodeType === 'method' && node.children.length === 0) {
-            return [node];
-        }
-        const result: TestTreeNode[] = [];
-        for (const child of node.children) {
-            result.push(...this.collectMethodNodes(child));
-        }
-        return result;
+        this.statusBar.updateResults(this.treeProvider.getAllMethodNodes());
     }
 
     private isCancelError(err: unknown): boolean {
         return err instanceof Error && err.message === 'Cancelled';
-    }
-
-    private updateStatusBar(): void {
-        const methods = this.treeProvider.getAllMethodNodes();
-        const passed = methods.filter((m) => m.state === 'passed').length;
-        const failed = methods.filter((m) => m.state === 'failed').length;
-        const total = methods.length;
-
-        if (failed > 0) {
-            this.statusBar.text = `$(error) ${passed}/${total} passed, ${failed} failed`;
-            this.statusBar.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
-        } else if (passed === total && total > 0) {
-            this.statusBar.text = `$(pass) ${total}/${total} passed`;
-            this.statusBar.backgroundColor = undefined;
-        } else {
-            this.statusBar.text = `$(beaker) ${total} C# test(s)`;
-            this.statusBar.backgroundColor = undefined;
-        }
     }
 
     dispose(): void {

--- a/src/ui/statusBarManager.ts
+++ b/src/ui/statusBarManager.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+import { TestTreeNode } from '../testTreeProvider';
+
+export class StatusBarManager implements vscode.Disposable {
+    private readonly statusBar: vscode.StatusBarItem;
+
+    constructor() {
+        this.statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+        this.statusBar.command = 'csharpTestExplorer.runAll';
+        this.statusBar.text = '$(beaker) C# Tests';
+        this.statusBar.show();
+    }
+
+    showDiscovering(): void {
+        this.statusBar.text = '$(loading~spin) Discovering C# tests...';
+    }
+
+    showNoProjects(): void {
+        this.statusBar.text = '$(beaker) No test projects';
+    }
+
+    showDiscovered(count: number): void {
+        this.statusBar.text = `$(beaker) ${count} C# test(s)`;
+    }
+
+    showDiscoveryFailed(): void {
+        this.statusBar.text = '$(error) Discovery failed';
+    }
+
+    showRunning(): void {
+        this.statusBar.text = '$(loading~spin) Running tests...';
+    }
+
+    showDebugging(): void {
+        this.statusBar.text = '$(debug) Debugging...';
+    }
+
+    updateResults(methods: TestTreeNode[]): void {
+        const passed = methods.filter((m) => m.state === 'passed').length;
+        const failed = methods.filter((m) => m.state === 'failed').length;
+        const total = methods.length;
+
+        if (failed > 0) {
+            this.statusBar.text = `$(error) ${passed}/${total} passed, ${failed} failed`;
+            this.statusBar.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+        } else if (passed === total && total > 0) {
+            this.statusBar.text = `$(pass) ${total}/${total} passed`;
+            this.statusBar.backgroundColor = undefined;
+        } else {
+            this.statusBar.text = `$(beaker) ${total} C# test(s)`;
+            this.statusBar.backgroundColor = undefined;
+        }
+    }
+
+    dispose(): void {
+        this.statusBar.dispose();
+    }
+}


### PR DESCRIPTION
## Summary

- Extract TRX result-to-tree-node matching logic into execution/resultMatcher.ts
- Rewrite execution/testRunner.ts to work with TestTreeNode, consolidating uildFilterForNode, collectMethodNodes, executeTests, and markRunningNodesAsFailed
- Rewrite debug/debugLauncher.ts to work with TestTreeNode via a single launchDebugSession entry point
- Extract status bar state management into ui/statusBarManager.ts
- Slim 	estController.ts from 535 to ~170 lines of pure orchestration (no domain logic)

Net result: **-238 lines** (338 added, 576 removed). No behavior change.

## Test plan

- [x] All 79 existing Vitest tests pass without modification
- [ ] Manual: Run a single test node — verify pass/fail states update correctly
- [ ] Manual: Run All — verify per-project execution and result matching
- [ ] Manual: Debug a test — verify VSTEST_HOST_DEBUG attach flow works
- [ ] Manual: Cancel a running test — verify nodes reset from running state
- [ ] Manual: Verify status bar shows correct counts after runs

Closes #12

Made with [Cursor](https://cursor.com)