### PR TITLE
refactor: eliminate duplicated code (DRY violations)

### DIFF
--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -23,7 +23,8 @@ src/
 ├── discovery/
 │   ├── projectDetector.ts    # Finds .csproj files in the workspace
 │   ├── dotnetDiscoverer.ts   # Runs `dotnet test --list-tests` to discover tests
-│   └── sourceMapper.ts       # Maps discovered tests back to source file locations
+│   ├── sourceMapper.ts       # Maps discovered tests back to source file locations
+│   └── patterns.ts           # Shared regex patterns for C# test attribute/class/method detection
 ├── execution/
 │   ├── testRunner.ts         # Executes `dotnet test` with filters
 │   ├── filterBuilder.ts      # Builds --filter expressions for dotnet test
@@ -35,7 +36,8 @@ src/
 │   └── statusBarManager.ts   # Status bar indicator for test runs
 └── utils/
     ├── outputChannel.ts      # Logging via VS Code OutputChannel
-    └── dotnetCli.ts          # Wrapper for spawning dotnet CLI processes
+    ├── dotnetCli.ts          # Wrapper for spawning dotnet CLI processes
+    └── testItemUtils.ts      # Shared helpers for TestItem tag storage and parent-chain lookups
 ```
 
 ## Key Flows

--- a/src/discovery/dotnetDiscoverer.ts
+++ b/src/discovery/dotnetDiscoverer.ts
@@ -2,6 +2,13 @@ import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import { log, logError } from '../utils/outputChannel';
 import { TestProject } from './projectDetector';
+import {
+    TEST_ATTRIBUTE_REGEX,
+    PARAMETERIZED_ATTRIBUTE_REGEX,
+    CLASS_REGEX,
+    METHOD_REGEX,
+    NAMESPACE_REGEX,
+} from './patterns';
 
 export interface DiscoveredTest {
     fullyQualifiedName: string;
@@ -15,16 +22,6 @@ export interface DiscoveredTest {
     sourceLine: number;
     parameters?: string;
 }
-
-const TEST_ATTR_REGEX =
-    /\[\s*(?:NUnit\.Framework\.|Xunit\.|Microsoft\.VisualStudio\.TestTools\.UnitTesting\.)?(Test|TestCase|TestCaseSource|Fact|Theory|TestMethod|DataTestMethod)\b/;
-const PARAMETERIZED_ATTR_REGEX =
-    /\[\s*(?:NUnit\.Framework\.|Xunit\.|Microsoft\.VisualStudio\.TestTools\.UnitTesting\.)?(TestCase|InlineData|DataRow)\s*\(/;
-const CLASS_REGEX =
-    /(?:public|internal)\s+(?:sealed\s+|abstract\s+|static\s+|partial\s+)*class\s+(\w+)/;
-const METHOD_REGEX =
-    /(?:public|internal|protected)\s+(?:static\s+|async\s+|virtual\s+|override\s+)*\S+\s+(\w+)\s*(?:<[^>]+>\s*)?\(/;
-const NAMESPACE_REGEX = /^\s*namespace\s+([\w.]+)/;
 
 export async function discoverTests(
     project: TestProject,
@@ -44,7 +41,7 @@ export async function discoverTests(
 
         try {
             const content = await fs.readFile(fileUri.fsPath, 'utf-8');
-            if (!TEST_ATTR_REGEX.test(content)) {
+            if (!TEST_ATTRIBUTE_REGEX.test(content)) {
                 continue;
             }
 
@@ -96,7 +93,7 @@ function parseTestMethods(
             classStack.push({ name: currentClass, depth: braceDepth });
         }
 
-        if (TEST_ATTR_REGEX.test(trimmed)) {
+        if (TEST_ATTRIBUTE_REGEX.test(trimmed)) {
             nextMethodIsTest = true;
         }
 
@@ -168,11 +165,11 @@ function parseTestMethods(
 
 /** Extracts the argument string from a parameterized test attribute, or undefined if not a match. */
 export function extractParameterArgs(line: string): string | undefined {
-    if (!PARAMETERIZED_ATTR_REGEX.test(line)) {
+    if (!PARAMETERIZED_ATTRIBUTE_REGEX.test(line)) {
         return undefined;
     }
 
-    const openParen = line.indexOf('(', line.search(PARAMETERIZED_ATTR_REGEX));
+    const openParen = line.indexOf('(', line.search(PARAMETERIZED_ATTRIBUTE_REGEX));
     if (openParen === -1) {
         return undefined;
     }

--- a/src/discovery/patterns.ts
+++ b/src/discovery/patterns.ts
@@ -1,0 +1,13 @@
+export const TEST_ATTRIBUTE_REGEX =
+    /\[\s*(?:NUnit\.Framework\.|Xunit\.|Microsoft\.VisualStudio\.TestTools\.UnitTesting\.)?(Test|TestCase|TestCaseSource|Fact|Theory|TestMethod|DataTestMethod)\b/;
+
+export const PARAMETERIZED_ATTRIBUTE_REGEX =
+    /\[\s*(?:NUnit\.Framework\.|Xunit\.|Microsoft\.VisualStudio\.TestTools\.UnitTesting\.)?(TestCase|InlineData|DataRow)\s*\(/;
+
+export const CLASS_REGEX =
+    /(?:public|internal)\s+(?:sealed\s+|abstract\s+|static\s+|partial\s+)*class\s+(\w+)/;
+
+export const METHOD_REGEX =
+    /(?:public|internal|protected)\s+(?:static\s+|async\s+|virtual\s+|override\s+)*\S+\s+(\w+)\s*(?:<[^>]+>\s*)?\(/;
+
+export const NAMESPACE_REGEX = /^\s*namespace\s+([\w.]+)/;

--- a/src/discovery/sourceMapper.ts
+++ b/src/discovery/sourceMapper.ts
@@ -1,20 +1,17 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import { logError } from '../utils/outputChannel';
+import {
+    TEST_ATTRIBUTE_REGEX,
+    CLASS_REGEX,
+    METHOD_REGEX,
+    NAMESPACE_REGEX,
+} from './patterns';
 
 export interface SourceLocation {
     uri: vscode.Uri;
     line: number;
 }
-
-// Matches: [Test], [TestCase(...)], [Fact], [Theory], [TestMethod], and variants with namespaces
-const TEST_ATTRIBUTE_PATTERN =
-    /\[\s*(?:NUnit\.Framework\.|Xunit\.|Microsoft\.VisualStudio\.TestTools\.UnitTesting\.)?(Test|TestCase|TestCaseSource|Fact|Theory|TestMethod|DataTestMethod)\b/;
-
-const CLASS_PATTERN = /(?:public|internal)\s+(?:sealed\s+|abstract\s+|static\s+)*class\s+(\w+)/;
-const METHOD_PATTERN =
-    /(?:public|internal|protected)\s+(?:static\s+|async\s+|virtual\s+|override\s+)*\S+\s+(\w+)\s*(?:<[^>]+>\s*)?\(/;
-const NAMESPACE_PATTERN = /namespace\s+([\w.]+)/;
 
 export async function buildSourceMap(projectDir: string): Promise<Map<string, SourceLocation>> {
     const testMap = new Map<string, SourceLocation>();
@@ -27,7 +24,7 @@ export async function buildSourceMap(projectDir: string): Promise<Map<string, So
     for (const fileUri of csFiles) {
         try {
             const content = await fs.readFile(fileUri.fsPath, 'utf-8');
-            if (!TEST_ATTRIBUTE_PATTERN.test(content)) {
+            if (!TEST_ATTRIBUTE_REGEX.test(content)) {
                 continue;
             }
 
@@ -57,13 +54,13 @@ function parseTestLocations(content: string, fileUri: vscode.Uri): Map<string, S
         const line = lines[i];
         const trimmed = line.trim();
 
-        const nsMatch = trimmed.match(NAMESPACE_PATTERN);
+        const nsMatch = trimmed.match(NAMESPACE_REGEX);
         if (nsMatch) {
             currentNamespace = nsMatch[1];
             continue;
         }
 
-        const classMatch = trimmed.match(CLASS_PATTERN);
+        const classMatch = trimmed.match(CLASS_REGEX);
         if (classMatch) {
             currentClass = classMatch[1];
             classStack.push({ name: currentClass, depth: braceDepth });
@@ -74,12 +71,12 @@ function parseTestLocations(content: string, fileUri: vscode.Uri): Map<string, S
             result.set(`class:${classKey}`, { uri: fileUri, line: i });
         }
 
-        if (TEST_ATTRIBUTE_PATTERN.test(trimmed)) {
+        if (TEST_ATTRIBUTE_REGEX.test(trimmed)) {
             nextMethodIsTest = true;
         }
 
         if (nextMethodIsTest) {
-            const methodMatch = trimmed.match(METHOD_PATTERN);
+            const methodMatch = trimmed.match(METHOD_REGEX);
             if (methodMatch) {
                 const methodName = methodMatch[1];
                 const fqn = currentNamespace

--- a/src/execution/filterBuilder.ts
+++ b/src/execution/filterBuilder.ts
@@ -1,4 +1,12 @@
 import * as vscode from 'vscode';
+import {
+    setTestItemData,
+    getTagValue,
+    getProjectPath,
+    getNodeType,
+    getFqn,
+    findProjectPath,
+} from '../utils/testItemUtils';
 
 /**
  * Builds a `dotnet test --filter` expression from a set of TestItems.
@@ -12,55 +20,11 @@ import * as vscode from 'vscode';
  * Filter syntax: https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests
  */
 
+export { setTestItemData, getTagValue, getProjectPath, getNodeType, getFqn };
+
 export interface FilterResult {
     filter: string | undefined;
     projectPath: string | undefined;
-}
-
-const TAG_PROJECT_PATH = 'projectPath';
-const TAG_NODE_TYPE = 'nodeType';
-const TAG_FQN = 'fqn';
-
-export function setTestItemData(
-    item: vscode.TestItem,
-    data: { projectPath?: string; nodeType?: string; fqn?: string },
-): void {
-    if (!item.tags) {
-        item.tags = [];
-    }
-    // We store metadata as prefixed tags since TestItem doesn't have a generic data slot
-    const tags: vscode.TestTag[] = [...item.tags];
-    if (data.projectPath) {
-        tags.push(new vscode.TestTag(`${TAG_PROJECT_PATH}:${data.projectPath}`));
-    }
-    if (data.nodeType) {
-        tags.push(new vscode.TestTag(`${TAG_NODE_TYPE}:${data.nodeType}`));
-    }
-    if (data.fqn) {
-        tags.push(new vscode.TestTag(`${TAG_FQN}:${data.fqn}`));
-    }
-    item.tags = tags;
-}
-
-export function getTagValue(item: vscode.TestItem, prefix: string): string | undefined {
-    for (const tag of item.tags) {
-        if (tag.id.startsWith(`${prefix}:`)) {
-            return tag.id.substring(prefix.length + 1);
-        }
-    }
-    return undefined;
-}
-
-export function getProjectPath(item: vscode.TestItem): string | undefined {
-    return getTagValue(item, TAG_PROJECT_PATH);
-}
-
-export function getNodeType(item: vscode.TestItem): string | undefined {
-    return getTagValue(item, TAG_NODE_TYPE);
-}
-
-export function getFqn(item: vscode.TestItem): string | undefined {
-    return getTagValue(item, TAG_FQN);
 }
 
 export function buildFilter(items: readonly vscode.TestItem[]): FilterResult {
@@ -107,18 +71,6 @@ export function buildFilter(items: readonly vscode.TestItem[]): FilterResult {
         expressions.length === 1 ? expressions[0] : expressions.map((e) => `(${e})`).join(' | ');
 
     return { filter, projectPath };
-}
-
-function findProjectPath(item: vscode.TestItem): string | undefined {
-    let current: vscode.TestItem | undefined = item;
-    while (current) {
-        const pp = getProjectPath(current);
-        if (pp) {
-            return pp;
-        }
-        current = current.parent;
-    }
-    return undefined;
 }
 
 function escapeFilter(value: string): string {

--- a/src/utils/testItemUtils.ts
+++ b/src/utils/testItemUtils.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode';
+
+const TAG_PROJECT_PATH = 'projectPath';
+const TAG_NODE_TYPE = 'nodeType';
+const TAG_FQN = 'fqn';
+
+export function setTestItemData(
+    item: vscode.TestItem,
+    data: { projectPath?: string; nodeType?: string; fqn?: string },
+): void {
+    if (!item.tags) {
+        item.tags = [];
+    }
+    // We store metadata as prefixed tags since TestItem doesn't have a generic data slot
+    const tags: vscode.TestTag[] = [...item.tags];
+    if (data.projectPath) {
+        tags.push(new vscode.TestTag(`${TAG_PROJECT_PATH}:${data.projectPath}`));
+    }
+    if (data.nodeType) {
+        tags.push(new vscode.TestTag(`${TAG_NODE_TYPE}:${data.nodeType}`));
+    }
+    if (data.fqn) {
+        tags.push(new vscode.TestTag(`${TAG_FQN}:${data.fqn}`));
+    }
+    item.tags = tags;
+}
+
+export function getTagValue(item: vscode.TestItem, prefix: string): string | undefined {
+    for (const tag of item.tags) {
+        if (tag.id.startsWith(`${prefix}:`)) {
+            return tag.id.substring(prefix.length + 1);
+        }
+    }
+    return undefined;
+}
+
+export function getProjectPath(item: vscode.TestItem): string | undefined {
+    return getTagValue(item, TAG_PROJECT_PATH);
+}
+
+export function getNodeType(item: vscode.TestItem): string | undefined {
+    return getTagValue(item, TAG_NODE_TYPE);
+}
+
+export function getFqn(item: vscode.TestItem): string | undefined {
+    return getTagValue(item, TAG_FQN);
+}
+
+export function findProjectPath(item: vscode.TestItem): string | undefined {
+    let current: vscode.TestItem | undefined = item;
+    while (current) {
+        const pp = getProjectPath(current);
+        if (pp) {
+            return pp;
+        }
+        current = current.parent;
+    }
+    return undefined;
+}


### PR DESCRIPTION
## Summary
- Extract shared regex patterns (test attributes, class, method, namespace) into `src/discovery/patterns.ts` so both `dotnetDiscoverer.ts` and `sourceMapper.ts` import from a single source
- Extract TestItem tag utilities (`setTestItemData`, `getProjectPath`, `findProjectPath`, etc.) into `src/utils/testItemUtils.ts`; `filterBuilder.ts` re-exports them for backward compatibility
- Update `project-context.mdc` with the two new modules

Closes #13

## Test plan
- [x] All 79 existing tests pass (`npm test`)
- [ ] Verify extension activates and discovers tests in a real workspace
- [ ] Verify test execution and debug still work end-to-end

Made with [Cursor](https://cursor.com)