### PR TITLE
refactor(trx): add type definitions for parsed TRX XML structure

### DIFF
--- a/src/execution/trxParser.ts
+++ b/src/execution/trxParser.ts
@@ -1,5 +1,58 @@
 import * as fs from 'fs/promises';
 
+// ── Parsed TRX XML interfaces ──
+// These mirror the structure returned by fast-xml-parser when parsing
+// a .trx file with `ignoreAttributes: false` and `attributeNamePrefix: '@_'`.
+
+export interface TrxErrorInfo {
+    Message?: string;
+    StackTrace?: string;
+}
+
+export interface TrxOutput {
+    ErrorInfo?: TrxErrorInfo;
+    StdOut?: string;
+}
+
+export interface TrxUnitTestResult {
+    '@_testId'?: string;
+    '@_testName'?: string;
+    '@_outcome'?: string;
+    '@_duration'?: string;
+    Output?: TrxOutput;
+}
+
+export interface TrxUnitTestDefinition {
+    '@_id'?: string;
+    '@_name'?: string;
+}
+
+export interface TrxCounters {
+    '@_total'?: string;
+    '@_passed'?: string;
+    '@_failed'?: string;
+}
+
+export interface TrxResultSummary {
+    Counters?: TrxCounters;
+}
+
+export interface TrxTestRun {
+    TestDefinitions?: {
+        UnitTest?: TrxUnitTestDefinition | TrxUnitTestDefinition[];
+    };
+    Results?: {
+        UnitTestResult?: TrxUnitTestResult | TrxUnitTestResult[];
+    };
+    ResultSummary?: TrxResultSummary;
+}
+
+export interface TrxDocument {
+    TestRun?: TrxTestRun;
+}
+
+// ── Public result types ──
+
 export type TestOutcome =
     | 'Passed'
     | 'Failed'
@@ -40,19 +93,18 @@ export function parseTrxXml(xml: string): TrxSummary {
         isArray: (name: string) => name === 'UnitTestResult' || name === 'UnitTest',
     });
 
-    const doc = parser.parse(xml);
-    const testRun = doc.TestRun;
+    const doc: TrxDocument = parser.parse(xml);
+    const testRun: TrxTestRun | undefined = doc.TestRun;
 
     if (!testRun) {
         return emptyResult();
     }
 
     const results: TestResult[] = [];
-    const unitTestResults = getArray(testRun.Results?.UnitTestResult);
+    const unitTestResults: TrxUnitTestResult[] = getArray(testRun.Results?.UnitTestResult);
 
-    // Build a map from testId -> testName using TestDefinitions
     const testDefs = new Map<string, string>();
-    const unitTests = getArray(testRun.TestDefinitions?.UnitTest);
+    const unitTests: TrxUnitTestDefinition[] = getArray(testRun.TestDefinitions?.UnitTest);
     for (const ut of unitTests) {
         const id = ut['@_id'];
         const name = ut['@_name'];
@@ -62,18 +114,18 @@ export function parseTrxXml(xml: string): TrxSummary {
     }
 
     for (const utr of unitTestResults) {
-        const testId = utr['@_testId'] ?? '';
-        const testName = utr['@_testName'] ?? testDefs.get(testId) ?? 'Unknown';
-        const outcome = mapOutcome(utr['@_outcome']);
-        const duration = parseDuration(utr['@_duration']);
+        const testId: string = utr['@_testId'] ?? '';
+        const testName: string = utr['@_testName'] ?? testDefs.get(testId) ?? 'Unknown';
+        const outcome: TestOutcome = mapOutcome(utr['@_outcome']);
+        const duration: number = parseDuration(utr['@_duration']);
 
         let errorMessage: string | undefined;
         let stackTrace: string | undefined;
         let stdout: string | undefined;
 
-        const output = utr.Output;
+        const output: TrxOutput | undefined = utr.Output;
         if (output) {
-            const errorInfo = output.ErrorInfo;
+            const errorInfo: TrxErrorInfo | undefined = output.ErrorInfo;
             if (errorInfo) {
                 errorMessage = errorInfo.Message ?? undefined;
                 stackTrace = errorInfo.StackTrace ?? undefined;
@@ -91,13 +143,13 @@ export function parseTrxXml(xml: string): TrxSummary {
         });
     }
 
-    const counters = testRun.ResultSummary?.Counters;
-    const total = parseInt(counters?.['@_total'] ?? '0', 10);
-    const passed = parseInt(counters?.['@_passed'] ?? '0', 10);
-    const failed = parseInt(counters?.['@_failed'] ?? '0', 10);
-    const skipped = total - passed - failed;
+    const counters: TrxCounters | undefined = testRun.ResultSummary?.Counters;
+    const total: number = parseInt(counters?.['@_total'] ?? '0', 10);
+    const passed: number = parseInt(counters?.['@_passed'] ?? '0', 10);
+    const failed: number = parseInt(counters?.['@_failed'] ?? '0', 10);
+    const skipped: number = total - passed - failed;
 
-    const totalDuration = results.reduce((sum, r) => sum + r.duration, 0);
+    const totalDuration: number = results.reduce((sum, r) => sum + r.duration, 0);
 
     return { total, passed, failed, skipped, duration: totalDuration, results };
 }


### PR DESCRIPTION
## Summary
- Defined TypeScript interfaces (TrxDocument, TrxTestRun, TrxUnitTestResult, TrxUnitTestDefinition, TrxCounters, TrxResultSummary, TrxOutput, TrxErrorInfo) that describe the TRX XML structure as parsed by ast-xml-parser
- Typed the output of parser.parse(xml) and all downstream property accesses so typos and invalid property names are caught at compile time
- All 79 existing tests continue to pass with no changes required

Closes #15

## Test plan
- [x] All existing tests pass (
px vitest run — 79/79 passing)
- [ ] Verify TypeScript compilation catches typos in TRX property names (e.g., rename a field in the interface and confirm a compile error)

Made with [Cursor](https://cursor.com)