### PR TITLE
chore: improve repo structure, fix docs, and add missing tests

### DIFF
--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -10,7 +10,7 @@ VS Code extension (TypeScript) that discovers, runs, and debugs C# tests (NUnit,
 
 ## Tech Stack
 - TypeScript, VS Code Extension API (^1.85.0)
-- Build: esbuild, compiled to `out/`
+- Build: tsc, compiled to `out/`
 - Activated when workspace contains `*.csproj`
 
 ## Architecture
@@ -18,8 +18,7 @@ VS Code extension (TypeScript) that discovers, runs, and debugs C# tests (NUnit,
 ```
 src/
 ├── extension.ts              # Entry point: activates CSharpTestController, registers commands
-├── testController.ts         # Core orchestrator: uses VS Code TestController API, wires discovery + execution
-├── testTreeProvider.ts       # TreeDataProvider for the sidebar test tree view
+├── testController.ts         # Core orchestrator: wires discovery + execution + debug
 ├── discovery/
 │   ├── projectDetector.ts    # Finds .csproj files in the workspace
 │   ├── dotnetDiscoverer.ts   # Runs `dotnet test --list-tests` to discover tests
@@ -33,6 +32,7 @@ src/
 ├── debug/
 │   └── debugLauncher.ts      # Launches dotnet test with debugger attached
 ├── ui/
+│   ├── testTreeProvider.ts   # TreeDataProvider for the sidebar test tree view
 │   └── statusBarManager.ts   # Status bar indicator for test runs
 └── utils/
     ├── outputChannel.ts      # Logging via VS Code OutputChannel
@@ -51,6 +51,8 @@ src/
 - `csharpTestExplorer.runTest` — run a specific tree node
 - `csharpTestExplorer.debugTest` — debug a specific tree node
 - `csharpTestExplorer.showOutput` — open the output channel
+- `csharpTestExplorer.goToTest` — navigate to a test's source location
+- `csharpTestExplorer.stopRun` — cancel an in-progress test run
 
 ## Keeping This Rule Up-to-Date
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+            "outFiles": ["${workspaceFolder}/out/**/*.js"],
+            "preLaunchTask": "npm: compile"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "compile",
+            "group": "build",
+            "problemMatcher": ["$tsc"],
+            "label": "npm: compile"
+        },
+        {
+            "type": "npm",
+            "script": "watch",
+            "group": "build",
+            "isBackground": true,
+            "problemMatcher": ["$tsc-watch"],
+            "label": "npm: watch"
+        }
+    ]
+}

--- a/src/debug/debugLauncher.ts
+++ b/src/debug/debugLauncher.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { ChildProcess } from 'child_process';
-import { TestTreeNode } from '../testTreeProvider';
+import { TestTreeNode } from '../ui/testTreeProvider';
 import { getExtraArgs } from '../utils/dotnetCli';
 import { log, logError, showOutput } from '../utils/outputChannel';
 import { buildFilterForNode } from '../execution/testRunner';

--- a/src/execution/resultMatcher.ts
+++ b/src/execution/resultMatcher.ts
@@ -1,4 +1,4 @@
-import { TestTreeProvider, TestTreeNode, TestState } from '../testTreeProvider';
+import { TestTreeProvider, TestTreeNode, TestState } from '../ui/testTreeProvider';
 import { TrxSummary } from './trxParser';
 import { log } from '../utils/outputChannel';
 

--- a/src/execution/testRunner.ts
+++ b/src/execution/testRunner.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import * as os from 'os';
-import { TestTreeProvider, TestTreeNode } from '../testTreeProvider';
+import { TestTreeProvider, TestTreeNode } from '../ui/testTreeProvider';
 import { runDotnet, getExtraArgs } from '../utils/dotnetCli';
 import { parseTrxFile } from './trxParser';
 import { log, logError } from '../utils/outputChannel';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { CSharpTestController } from './testController';
-import { TestTreeNode } from './testTreeProvider';
+import { TestTreeNode } from './ui/testTreeProvider';
 import { disposeChannel, log, showOutput } from './utils/outputChannel';
 
 let controller: CSharpTestController | undefined;

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { detectTestProjects, TestProject } from './discovery/projectDetector';
 import { discoverTests, DiscoveredTest } from './discovery/dotnetDiscoverer';
-import { TestTreeProvider, TestTreeNode } from './testTreeProvider';
+import { TestTreeProvider, TestTreeNode } from './ui/testTreeProvider';
 import { StatusBarManager } from './ui/statusBarManager';
 import {
     executeTests,
@@ -10,8 +10,6 @@ import {
 } from './execution/testRunner';
 import { launchDebugSession } from './debug/debugLauncher';
 import { log, logError, showOutput } from './utils/outputChannel';
-
-export { normalizeTestName } from './execution/resultMatcher';
 
 export class CSharpTestController implements vscode.Disposable {
     readonly treeProvider: TestTreeProvider;

--- a/src/ui/statusBarManager.ts
+++ b/src/ui/statusBarManager.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { TestTreeNode } from '../testTreeProvider';
+import { TestTreeNode } from './testTreeProvider';
 
 export class StatusBarManager implements vscode.Disposable {
     private readonly statusBar: vscode.StatusBarItem;

--- a/src/ui/testTreeProvider.ts
+++ b/src/ui/testTreeProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { DiscoveredTest } from './discovery/dotnetDiscoverer';
-import { TestProject } from './discovery/projectDetector';
+import { DiscoveredTest } from '../discovery/dotnetDiscoverer';
+import { TestProject } from '../discovery/projectDetector';
 
 export type TestNodeType = 'project' | 'namespace' | 'class' | 'method' | 'parameterizedCase';
 export type TestState = 'none' | 'running' | 'passed' | 'failed' | 'skipped';

--- a/test/execution/resultMatcher.test.ts
+++ b/test/execution/resultMatcher.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('vscode', () => {
+    const EventEmitter = class {
+        fire = vi.fn();
+        dispose = vi.fn();
+        event = vi.fn();
+    };
+
+    return {
+        EventEmitter,
+        TreeItem: class {
+            constructor(
+                public label: string,
+                public collapsibleState?: number,
+            ) {}
+        },
+        TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+        ThemeIcon: class {
+            constructor(
+                public id: string,
+                public color?: unknown,
+            ) {}
+        },
+        ThemeColor: class {
+            constructor(public id: string) {}
+        },
+        Uri: {
+            file: (p: string) => ({ fsPath: p, toString: () => p }),
+        },
+        Range: class {
+            constructor(
+                public startLine: number,
+                public startCol: number,
+                public endLine: number,
+                public endCol: number,
+            ) {}
+        },
+        window: {
+            createOutputChannel: () => ({
+                appendLine: vi.fn(),
+                show: vi.fn(),
+                dispose: vi.fn(),
+            }),
+        },
+    };
+});
+
+vi.mock('../../src/utils/outputChannel', () => ({
+    log: vi.fn(),
+    logError: vi.fn(),
+}));
+
+import { TestTreeProvider, TestTreeNode } from '../../src/ui/testTreeProvider';
+import { applyResultState, matchAndApplyResults } from '../../src/execution/resultMatcher';
+import type { TrxSummary } from '../../src/execution/trxParser';
+
+function makeMethodNode(fqn: string, projectPath = '/proj.csproj'): TestTreeNode {
+    const node = new TestTreeNode(`method:${projectPath}:${fqn}`, fqn.split('.').pop()!, 'method', fqn);
+    node.projectPath = projectPath;
+    return node;
+}
+
+describe('applyResultState', () => {
+    let treeProvider: TestTreeProvider;
+
+    beforeEach(() => {
+        treeProvider = new TestTreeProvider();
+    });
+
+    it('should set the node state to the given value', () => {
+        const node = makeMethodNode('NS.Class.Test1');
+
+        applyResultState(node, 'passed', undefined, treeProvider);
+
+        expect(node.state).toBe('passed');
+    });
+
+    it('should apply error details to the node', () => {
+        const node = makeMethodNode('NS.Class.Test1');
+        const details = {
+            errorMessage: 'Expected true but got false',
+            stackTrace: 'at NS.Class.Test1() in Class.cs:line 10',
+            duration: 150,
+        };
+
+        applyResultState(node, 'failed', details, treeProvider);
+
+        expect(node.state).toBe('failed');
+        expect(node.errorMessage).toBe('Expected true but got false');
+        expect(node.stackTrace).toBe('at NS.Class.Test1() in Class.cs:line 10');
+        expect(node.duration).toBe(150);
+    });
+
+    it('should not overwrite fields when details is undefined', () => {
+        const node = makeMethodNode('NS.Class.Test1');
+        node.errorMessage = 'old error';
+
+        applyResultState(node, 'passed', undefined, treeProvider);
+
+        expect(node.state).toBe('passed');
+        expect(node.errorMessage).toBe('old error');
+    });
+});
+
+describe('matchAndApplyResults', () => {
+    let treeProvider: TestTreeProvider;
+
+    beforeEach(() => {
+        treeProvider = new TestTreeProvider();
+        vi.clearAllMocks();
+    });
+
+    it('should match by exact FQN', () => {
+        const node = makeMethodNode('MyNamespace.MyClass.TestMethod');
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration: 100,
+            results: [{ testName: 'MyNamespace.MyClass.TestMethod', outcome: 'Passed', duration: 100 }],
+        };
+
+        matchAndApplyResults(summary, [node], treeProvider);
+
+        expect(node.state).toBe('passed');
+    });
+
+    it('should match by normalized name stripping spaces after commas', () => {
+        const node = makeMethodNode('NS.Class.Add(1,2,3)');
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration: 50,
+            results: [{ testName: 'NS.Class.Add(1, 2, 3)', outcome: 'Passed', duration: 50 }],
+        };
+
+        matchAndApplyResults(summary, [node], treeProvider);
+
+        expect(node.state).toBe('passed');
+    });
+
+    it('should match by short name fallback when FQN does not match', () => {
+        const node = makeMethodNode('MyNamespace.MyClass.SomeTest');
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 0,
+            failed: 1,
+            skipped: 0,
+            duration: 200,
+            results: [
+                {
+                    testName: 'DifferentNamespace.DifferentClass.SomeTest',
+                    outcome: 'Failed',
+                    errorMessage: 'Assertion failed',
+                    duration: 200,
+                },
+            ],
+        };
+
+        matchAndApplyResults(summary, [node], treeProvider);
+
+        expect(node.state).toBe('failed');
+        expect(node.errorMessage).toBe('Assertion failed');
+    });
+
+    it('should map Failed outcome to failed state', () => {
+        const node = makeMethodNode('NS.Class.Test1');
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 0,
+            failed: 1,
+            skipped: 0,
+            duration: 0,
+            results: [{ testName: 'NS.Class.Test1', outcome: 'Failed', duration: 0 }],
+        };
+
+        matchAndApplyResults(summary, [node], treeProvider);
+
+        expect(node.state).toBe('failed');
+    });
+
+    it('should map Error outcome to failed state', () => {
+        const node = makeMethodNode('NS.Class.Test1');
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 0,
+            failed: 1,
+            skipped: 0,
+            duration: 0,
+            results: [{ testName: 'NS.Class.Test1', outcome: 'Error', duration: 0 }],
+        };
+
+        matchAndApplyResults(summary, [node], treeProvider);
+
+        expect(node.state).toBe('failed');
+    });
+
+    it('should map Timeout outcome to failed state', () => {
+        const node = makeMethodNode('NS.Class.Test1');
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 0,
+            failed: 1,
+            skipped: 0,
+            duration: 0,
+            results: [{ testName: 'NS.Class.Test1', outcome: 'Timeout', duration: 0 }],
+        };
+
+        matchAndApplyResults(summary, [node], treeProvider);
+
+        expect(node.state).toBe('failed');
+    });
+
+    it('should map NotExecuted outcome to skipped state', () => {
+        const node = makeMethodNode('NS.Class.Test1');
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 0,
+            failed: 0,
+            skipped: 1,
+            duration: 0,
+            results: [{ testName: 'NS.Class.Test1', outcome: 'NotExecuted', duration: 0 }],
+        };
+
+        matchAndApplyResults(summary, [node], treeProvider);
+
+        expect(node.state).toBe('skipped');
+    });
+
+    it('should match multiple results to their corresponding nodes', () => {
+        const node1 = makeMethodNode('NS.Class.Test1');
+        const node2 = makeMethodNode('NS.Class.Test2');
+        const summary: TrxSummary = {
+            total: 2,
+            passed: 1,
+            failed: 1,
+            skipped: 0,
+            duration: 300,
+            results: [
+                { testName: 'NS.Class.Test1', outcome: 'Passed', duration: 100 },
+                { testName: 'NS.Class.Test2', outcome: 'Failed', duration: 200 },
+            ],
+        };
+
+        matchAndApplyResults(summary, [node1, node2], treeProvider);
+
+        expect(node1.state).toBe('passed');
+        expect(node2.state).toBe('failed');
+    });
+
+    it('should match by suffix when TRX uses full FQN and node uses partial', () => {
+        const node = makeMethodNode('Class.TestMethod');
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration: 50,
+            results: [{ testName: 'MyNamespace.Class.TestMethod', outcome: 'Passed', duration: 50 }],
+        };
+
+        matchAndApplyResults(summary, [node], treeProvider);
+
+        expect(node.state).toBe('passed');
+    });
+
+    it('should match base name without parameters when exact match fails', () => {
+        const node = makeMethodNode('NS.Class.Add');
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration: 50,
+            results: [{ testName: 'NS.Class.Add(1,2,3)', outcome: 'Passed', duration: 50 }],
+        };
+
+        matchAndApplyResults(summary, [node], treeProvider);
+
+        expect(node.state).toBe('passed');
+    });
+
+    it('should handle empty results gracefully', () => {
+        const node = makeMethodNode('NS.Class.Test1');
+        const summary: TrxSummary = {
+            total: 0,
+            passed: 0,
+            failed: 0,
+            skipped: 0,
+            duration: 0,
+            results: [],
+        };
+
+        matchAndApplyResults(summary, [node], treeProvider);
+
+        expect(node.state).toBe('none');
+    });
+
+    it('should handle empty method nodes gracefully', () => {
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration: 50,
+            results: [{ testName: 'NS.Class.Test1', outcome: 'Passed', duration: 50 }],
+        };
+
+        expect(() => matchAndApplyResults(summary, [], treeProvider)).not.toThrow();
+    });
+});

--- a/test/testController.test.ts
+++ b/test/testController.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeTestName } from '../src/testController';
+import { normalizeTestName } from '../src/execution/resultMatcher';
 
 describe('normalizeTestName', () => {
     it('should return name unchanged when there are no parameters', () => {

--- a/test/ui/testTreeProvider.test.ts
+++ b/test/ui/testTreeProvider.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('vscode', () => {
+    const EventEmitter = class {
+        fire = vi.fn();
+        dispose = vi.fn();
+        event = vi.fn();
+    };
+
+    return {
+        EventEmitter,
+        TreeItem: class {
+            constructor(
+                public label: string,
+                public collapsibleState?: number,
+            ) {}
+        },
+        TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+        ThemeIcon: class {
+            constructor(
+                public id: string,
+                public color?: unknown,
+            ) {}
+        },
+        ThemeColor: class {
+            constructor(public id: string) {}
+        },
+        Uri: {
+            file: (p: string) => ({ fsPath: p, toString: () => p }),
+        },
+        Range: class {
+            constructor(
+                public startLine: number,
+                public startCol: number,
+                public endLine: number,
+                public endCol: number,
+            ) {}
+        },
+    };
+});
+
+import { TestTreeProvider, TestTreeNode } from '../../src/ui/testTreeProvider';
+import type { TestProject } from '../../src/discovery/projectDetector';
+import type { DiscoveredTest } from '../../src/discovery/dotnetDiscoverer';
+
+function makeProject(name: string, csprojPath: string): TestProject {
+    return {
+        projectName: name,
+        csprojPath,
+        projectDir: csprojPath.replace(/[/\\][^/\\]+$/, ''),
+    };
+}
+
+function makeTest(
+    ns: string,
+    cls: string,
+    method: string,
+    overrides: Partial<DiscoveredTest> = {},
+): DiscoveredTest {
+    return {
+        fullyQualifiedName: `${ns}.${cls}.${method}`,
+        namespace: ns,
+        className: cls,
+        methodName: method,
+        displayName: method,
+        sourceFile: `${cls}.cs`,
+        ...overrides,
+    } as DiscoveredTest;
+}
+
+function buildSingleProjectTree(
+    projectName: string,
+    tests: DiscoveredTest[],
+): TestTreeProvider {
+    const provider = new TestTreeProvider();
+    const project = makeProject(projectName, `/repo/${projectName}/${projectName}.csproj`);
+    const testsByProject = new Map<string, DiscoveredTest[]>();
+    testsByProject.set(project.csprojPath, tests);
+    provider.buildTree([project], testsByProject);
+    return provider;
+}
+
+describe('TestTreeNode', () => {
+    it('should produce contextValue from nodeType and state', () => {
+        const node = new TestTreeNode('id-1', 'MyTest', 'method', 'NS.Class.MyTest');
+
+        expect(node.contextValue).toBe('testNode.method.none');
+    });
+
+    it('should update contextValue when state changes', () => {
+        const node = new TestTreeNode('id-1', 'MyTest', 'method', 'NS.Class.MyTest');
+
+        node.state = 'passed';
+
+        expect(node.contextValue).toBe('testNode.method.passed');
+    });
+
+    it('should default state to none and children to empty', () => {
+        const node = new TestTreeNode('id-1', 'MyTest', 'method', 'NS.Class.MyTest');
+
+        expect(node.state).toBe('none');
+        expect(node.children).toEqual([]);
+    });
+});
+
+describe('TestTreeProvider.buildTree', () => {
+    it('should create project root node', () => {
+        const provider = buildSingleProjectTree('MyProject', [
+            makeTest('NS', 'Class1', 'Test1'),
+        ]);
+
+        const roots = provider.getRoots();
+
+        expect(roots).toHaveLength(1);
+        expect(roots[0].nodeType).toBe('project');
+        expect(roots[0].label).toContain('MyProject');
+    });
+
+    it('should create namespace node under project', () => {
+        const provider = buildSingleProjectTree('MyProject', [
+            makeTest('MyNamespace', 'Class1', 'Test1'),
+        ]);
+
+        const roots = provider.getRoots();
+        const nsNode = roots[0].children[0];
+
+        expect(nsNode.nodeType).toBe('namespace');
+        expect(nsNode.label).toBe('MyNamespace');
+    });
+
+    it('should create class node under namespace', () => {
+        const provider = buildSingleProjectTree('MyProject', [
+            makeTest('NS', 'MyClass', 'Test1'),
+        ]);
+
+        const classNode = provider.getRoots()[0].children[0].children[0];
+
+        expect(classNode.nodeType).toBe('class');
+        expect(classNode.label).toContain('MyClass');
+    });
+
+    it('should create method node under class', () => {
+        const provider = buildSingleProjectTree('MyProject', [
+            makeTest('NS', 'MyClass', 'Test1'),
+        ]);
+
+        const methodNode = provider.getRoots()[0].children[0].children[0].children[0];
+
+        expect(methodNode.nodeType).toBe('method');
+        expect(methodNode.displayName ?? methodNode.label).toBe('Test1');
+    });
+
+    it('should group tests by namespace', () => {
+        const provider = buildSingleProjectTree('MyProject', [
+            makeTest('NS1', 'Class1', 'Test1'),
+            makeTest('NS2', 'Class2', 'Test2'),
+        ]);
+
+        const nsNodes = provider.getRoots()[0].children;
+
+        expect(nsNodes).toHaveLength(2);
+        expect(nsNodes.map((n) => n.label).sort()).toEqual(['NS1', 'NS2']);
+    });
+
+    it('should group tests by class within namespace', () => {
+        const provider = buildSingleProjectTree('MyProject', [
+            makeTest('NS', 'ClassA', 'Test1'),
+            makeTest('NS', 'ClassB', 'Test2'),
+        ]);
+
+        const classNodes = provider.getRoots()[0].children[0].children;
+
+        expect(classNodes).toHaveLength(2);
+    });
+
+    it('should group parameterized cases under a method node', () => {
+        const provider = buildSingleProjectTree('MyProject', [
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(1,2)',
+                displayName: 'Add(1,2)',
+                parameters: '1,2',
+            }),
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(3,4)',
+                displayName: 'Add(3,4)',
+                parameters: '3,4',
+            }),
+        ]);
+
+        const classNode = provider.getRoots()[0].children[0].children[0];
+        const methodNode = classNode.children[0];
+
+        expect(methodNode.nodeType).toBe('method');
+        expect(methodNode.children).toHaveLength(2);
+        expect(methodNode.children[0].nodeType).toBe('parameterizedCase');
+        expect(methodNode.children[1].nodeType).toBe('parameterizedCase');
+    });
+
+    it('should skip projects with no tests', () => {
+        const provider = new TestTreeProvider();
+        const project1 = makeProject('Empty', '/repo/Empty/Empty.csproj');
+        const project2 = makeProject('HasTests', '/repo/HasTests/HasTests.csproj');
+        const testsByProject = new Map<string, DiscoveredTest[]>();
+        testsByProject.set(project1.csprojPath, []);
+        testsByProject.set(project2.csprojPath, [makeTest('NS', 'Cls', 'Test1')]);
+
+        provider.buildTree([project1, project2], testsByProject);
+
+        expect(provider.getRoots()).toHaveLength(1);
+        expect(provider.getRoots()[0].label).toContain('HasTests');
+    });
+
+    it('should set projectPath on all nodes', () => {
+        const provider = buildSingleProjectTree('MyProject', [
+            makeTest('NS', 'Cls', 'Test1'),
+        ]);
+
+        const root = provider.getRoots()[0];
+        const ns = root.children[0];
+        const cls = ns.children[0];
+        const method = cls.children[0];
+
+        const expectedPath = '/repo/MyProject/MyProject.csproj';
+        expect(root.projectPath).toBe(expectedPath);
+        expect(ns.projectPath).toBe(expectedPath);
+        expect(cls.projectPath).toBe(expectedPath);
+        expect(method.projectPath).toBe(expectedPath);
+    });
+
+    it('should show method count in class label', () => {
+        const provider = buildSingleProjectTree('MyProject', [
+            makeTest('NS', 'Cls', 'Test1'),
+            makeTest('NS', 'Cls', 'Test2'),
+        ]);
+
+        const classNode = provider.getRoots()[0].children[0].children[0];
+
+        expect(classNode.label).toBe('Cls (2)');
+    });
+});
+
+describe('TestTreeProvider.getChildren', () => {
+    it('should return roots when called without element', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'T1')]);
+
+        const children = provider.getChildren();
+
+        expect(children).toEqual(provider.getRoots());
+    });
+
+    it('should return children of the given element', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'T1')]);
+        const root = provider.getRoots()[0];
+
+        const children = provider.getChildren(root);
+
+        expect(children).toEqual(root.children);
+    });
+});
+
+describe('TestTreeProvider.getParent', () => {
+    it('should return the parent of a child node', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'T1')]);
+        const root = provider.getRoots()[0];
+        const nsNode = root.children[0];
+
+        const parent = provider.getParent(nsNode);
+
+        expect(parent).toBe(root);
+    });
+
+    it('should return undefined for root nodes', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'T1')]);
+        const root = provider.getRoots()[0];
+
+        const parent = provider.getParent(root);
+
+        expect(parent).toBeUndefined();
+    });
+});
+
+describe('TestTreeProvider.getNodeByFqn', () => {
+    it('should find a node by its exact FQN', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);
+
+        const node = provider.getNodeByFqn('NS.Cls.Test1');
+
+        expect(node).toBeDefined();
+        expect(node?.fqn).toBe('NS.Cls.Test1');
+    });
+
+    it('should return undefined for non-existent FQN', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);
+
+        const node = provider.getNodeByFqn('NS.Cls.NonExistent');
+
+        expect(node).toBeUndefined();
+    });
+});
+
+describe('TestTreeProvider.getAllMethodNodes', () => {
+    it('should return all method and parameterizedCase nodes', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Test1'),
+            makeTest('NS', 'Cls', 'Test2'),
+        ]);
+
+        const methods = provider.getAllMethodNodes();
+
+        expect(methods).toHaveLength(2);
+        expect(methods.every((m) => m.nodeType === 'method')).toBe(true);
+    });
+
+    it('should include parameterized cases', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(1)',
+                displayName: 'Add(1)',
+                parameters: '1',
+            }),
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(2)',
+                displayName: 'Add(2)',
+                parameters: '2',
+            }),
+        ]);
+
+        const methods = provider.getAllMethodNodes();
+        const cases = methods.filter((m) => m.nodeType === 'parameterizedCase');
+
+        expect(cases).toHaveLength(2);
+    });
+});
+
+describe('TestTreeProvider.getLeafTestNodes', () => {
+    it('should return methods without children', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'SimpleTest'),
+        ]);
+
+        const leaves = provider.getLeafTestNodes();
+
+        expect(leaves).toHaveLength(1);
+        expect(leaves[0].nodeType).toBe('method');
+    });
+
+    it('should return parameterized cases but not their parent method', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(1)',
+                displayName: 'Add(1)',
+                parameters: '1',
+            }),
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(2)',
+                displayName: 'Add(2)',
+                parameters: '2',
+            }),
+        ]);
+
+        const leaves = provider.getLeafTestNodes();
+
+        expect(leaves).toHaveLength(2);
+        expect(leaves.every((l) => l.nodeType === 'parameterizedCase')).toBe(true);
+    });
+});
+
+describe('TestTreeProvider.clearRunningStates', () => {
+    it('should reset running nodes to none', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'T1')]);
+        const method = provider.getAllMethodNodes()[0];
+        method.state = 'running';
+
+        provider.clearRunningStates();
+
+        expect(method.state).toBe('none');
+    });
+
+    it('should not affect non-running nodes', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'T1'),
+            makeTest('NS', 'Cls', 'T2'),
+        ]);
+        const [m1, m2] = provider.getAllMethodNodes();
+        m1.state = 'passed';
+        m2.state = 'running';
+
+        provider.clearRunningStates();
+
+        expect(m1.state).toBe('passed');
+        expect(m2.state).toBe('none');
+    });
+});
+
+describe('TestTreeProvider.resetAllStates', () => {
+    it('should reset all nodes to none and clear error data', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'T1')]);
+        const method = provider.getAllMethodNodes()[0];
+        method.state = 'failed';
+        method.errorMessage = 'some error';
+        method.stackTrace = 'some trace';
+        method.duration = 500;
+
+        provider.resetAllStates();
+
+        expect(method.state).toBe('none');
+        expect(method.errorMessage).toBeUndefined();
+        expect(method.stackTrace).toBeUndefined();
+        expect(method.duration).toBeUndefined();
+    });
+});
+
+describe('TestTreeProvider.addDynamicCaseNode', () => {
+    it('should add a new parameterized case under an existing method', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(1)',
+                displayName: 'Add(1)',
+                parameters: '1',
+            }),
+        ]);
+
+        const added = provider.addDynamicCaseNode('NS.Cls.Add', 'NS.Cls.Add(99)', 'Add(99)');
+
+        expect(added).toBeDefined();
+        expect(added?.nodeType).toBe('parameterizedCase');
+        expect(added?.fqn).toBe('NS.Cls.Add(99)');
+    });
+
+    it('should return existing node when FQN already exists', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(1)',
+                displayName: 'Add(1)',
+                parameters: '1',
+            }),
+        ]);
+
+        const existing = provider.addDynamicCaseNode('NS.Cls.Add', 'NS.Cls.Add(1)', 'Add(1)');
+
+        expect(existing).toBeDefined();
+        expect(existing?.fqn).toBe('NS.Cls.Add(1)');
+    });
+
+    it('should return undefined when parent FQN does not exist', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);
+
+        const result = provider.addDynamicCaseNode('NS.Cls.NonExistent', 'NS.Cls.NonExistent(1)', 'NonExistent(1)');
+
+        expect(result).toBeUndefined();
+    });
+});
+
+describe('TestTreeProvider.getNodeById', () => {
+    it('should return the node matching the given id', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);
+        const root = provider.getRoots()[0];
+
+        const found = provider.getNodeById(root.id);
+
+        expect(found).toBe(root);
+    });
+
+    it('should return undefined for a non-existent id', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);
+
+        const found = provider.getNodeById('non-existent-id');
+
+        expect(found).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary
- **Fix project-context.mdc**: corrected build tool from "esbuild" to "tsc", added missing commands (`goToTest`, `stopRun`), and updated architecture tree to reflect the `testTreeProvider.ts` move
- **Move `testTreeProvider.ts` to `src/ui/`**: groups all UI concerns (`testTreeProvider`, `statusBarManager`) under the same directory for consistency
- **Remove unnecessary re-export**: `normalizeTestName` was re-exported through `testController.ts` — consumers now import directly from `execution/resultMatcher`
- **Add `.vscode/launch.json` + `tasks.json`**: enables F5 Extension Development Host workflow out of the box
- **Add 46 new unit tests**: covers `resultMatcher` (outcome mapping, multi-pass matching, normalization) and `testTreeProvider` (tree building, state management, dynamic nodes, lookup methods)

## Test plan
- [x] All 125 tests pass (`npx vitest run`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] ESLint passes with zero errors or warnings
- [x] Pre-commit README check passes
