### PR TITLE
refactor: make outputChannel injectable via Logger interface

### DIFF
--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -35,7 +35,8 @@ src/
 │   ├── testTreeProvider.ts   # TreeDataProvider for the sidebar test tree view
 │   └── statusBarManager.ts   # Status bar indicator for test runs
 └── utils/
-    ├── outputChannel.ts      # Logging via VS Code OutputChannel
+    ├── logger.ts             # Logger interface for injectable logging abstraction
+    ├── outputChannel.ts      # OutputChannelLogger implementation + convenience wrappers
     ├── dotnetCli.ts          # Wrapper for spawning dotnet CLI processes
     └── testItemUtils.ts      # Shared helpers for TestItem tag storage and parent-chain lookups
 ```

--- a/src/debug/debugLauncher.ts
+++ b/src/debug/debugLauncher.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { ChildProcess } from 'child_process';
 import { TestTreeNode } from '../ui/testTreeProvider';
 import { getExtraArgs } from '../utils/dotnetCli';
-import { log, logError, showOutput } from '../utils/outputChannel';
+import { Logger } from '../utils/logger';
 import { buildFilterForNode } from '../execution/testRunner';
 
 const PID_REGEX = /Process Id:\s*(\d+)/;
@@ -11,9 +11,10 @@ const PID_REGEX = /Process Id:\s*(\d+)/;
 export async function launchDebugSession(
     node: TestTreeNode,
     token: vscode.CancellationToken,
+    logger: Logger,
 ): Promise<void> {
     if (!node.projectPath) {
-        logError('No project path for node');
+        logger.logError('No project path for node');
         return;
     }
 
@@ -30,16 +31,16 @@ export async function launchDebugSession(
         args.push(...extraArgs);
     }
 
-    log('Starting test host with VSTEST_HOST_DEBUG=1...');
-    showOutput();
+    logger.log('Starting test host with VSTEST_HOST_DEBUG=1...');
+    logger.showOutput();
 
     const { spawnDotnet } = await import('../utils/dotnetCli');
-    const proc = spawnDotnet(args, projectDir, { VSTEST_HOST_DEBUG: '1' });
+    const proc = spawnDotnet(args, projectDir, logger, { VSTEST_HOST_DEBUG: '1' });
 
     try {
         const pid = await waitForPid(proc, token);
 
-        log(`Test host PID: ${pid}. Attaching debugger...`);
+        logger.log(`Test host PID: ${pid}. Attaching debugger...`);
 
         const debugConfig: vscode.DebugConfiguration = {
             type: 'coreclr',
@@ -52,7 +53,7 @@ export async function launchDebugSession(
         const started = await vscode.debug.startDebugging(folder, debugConfig);
 
         if (!started) {
-            logError('Failed to attach debugger');
+            logger.logError('Failed to attach debugger');
             proc.kill();
             return;
         }
@@ -65,11 +66,11 @@ export async function launchDebugSession(
             });
         });
 
-        log('Debug session completed.');
+        logger.log('Debug session completed.');
     } catch (err) {
         proc.kill();
         if (!(err instanceof Error && err.message === 'Cancelled')) {
-            logError('Debug failed', err);
+            logger.logError('Debug failed', err);
         }
     }
 }

--- a/src/discovery/dotnetDiscoverer.ts
+++ b/src/discovery/dotnetDiscoverer.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
-import { log, logError } from '../utils/outputChannel';
+import { Logger } from '../utils/logger';
 import { TestProject } from './projectDetector';
 import {
     TEST_ATTRIBUTE_REGEX,
@@ -25,6 +25,7 @@ export interface DiscoveredTest {
 
 export async function discoverTests(
     project: TestProject,
+    logger: Logger,
     token?: vscode.CancellationToken,
 ): Promise<DiscoveredTest[]> {
     const tests: DiscoveredTest[] = [];
@@ -48,11 +49,11 @@ export async function discoverTests(
             const fileMethods = parseTestMethods(content, fileUri, project);
             tests.push(...fileMethods);
         } catch (err) {
-            logError(`Failed to parse ${fileUri.fsPath}`, err);
+            logger.logError(`Failed to parse ${fileUri.fsPath}`, err);
         }
     }
 
-    log(`Found ${tests.length} test(s) in ${project.projectName}`);
+    logger.log(`Found ${tests.length} test(s) in ${project.projectName}`);
     return tests;
 }
 

--- a/src/discovery/projectDetector.ts
+++ b/src/discovery/projectDetector.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs/promises';
-import { log, logError } from '../utils/outputChannel';
+import { Logger } from '../utils/logger';
 
 const TEST_FRAMEWORK_PACKAGES = [
     'nunit',
@@ -21,7 +21,7 @@ export interface TestProject {
     frameworks: string[];
 }
 
-export async function detectTestProjects(): Promise<TestProject[]> {
+export async function detectTestProjects(logger: Logger): Promise<TestProject[]> {
     const excludePatterns = vscode.workspace
         .getConfiguration('csharpTestExplorer')
         .get<string[]>('excludeProjects', []);
@@ -53,11 +53,11 @@ export async function detectTestProjects(): Promise<TestProject[]> {
                 });
             }
         } catch (err) {
-            logError(`Failed to read ${filePath}`, err);
+            logger.logError(`Failed to read ${filePath}`, err);
         }
     }
 
-    log(
+    logger.log(
         `Detected ${projects.length} test project(s): ${projects.map((p) => p.projectName).join(', ')}`,
     );
     return projects;

--- a/src/discovery/sourceMapper.ts
+++ b/src/discovery/sourceMapper.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
-import { logError } from '../utils/outputChannel';
+import { Logger } from '../utils/logger';
 import {
     TEST_ATTRIBUTE_REGEX,
     CLASS_REGEX,
@@ -13,7 +13,10 @@ export interface SourceLocation {
     line: number;
 }
 
-export async function buildSourceMap(projectDir: string): Promise<Map<string, SourceLocation>> {
+export async function buildSourceMap(
+    projectDir: string,
+    logger: Logger,
+): Promise<Map<string, SourceLocation>> {
     const testMap = new Map<string, SourceLocation>();
 
     const csFiles = await vscode.workspace.findFiles(
@@ -33,7 +36,7 @@ export async function buildSourceMap(projectDir: string): Promise<Map<string, So
                 testMap.set(key, loc);
             }
         } catch (err) {
-            logError(`Failed to parse ${fileUri.fsPath}`, err);
+            logger.logError(`Failed to parse ${fileUri.fsPath}`, err);
         }
     }
 

--- a/src/execution/resultMatcher.ts
+++ b/src/execution/resultMatcher.ts
@@ -1,6 +1,6 @@
 import { TestTreeProvider, TestTreeNode, TestState } from '../ui/testTreeProvider';
 import { TrxSummary } from './trxParser';
-import { log } from '../utils/outputChannel';
+import { Logger } from '../utils/logger';
 
 export interface ResultDetails {
     errorMessage?: string;
@@ -47,6 +47,7 @@ export function matchAndApplyResults(
     summary: TrxSummary,
     methodNodes: TestTreeNode[],
     treeProvider: TestTreeProvider,
+    logger: Logger,
 ): void {
     const methodsByName = new Map<string, TestTreeNode[]>();
     for (const m of methodNodes) {
@@ -117,11 +118,11 @@ export function matchAndApplyResults(
         }
 
         if (!matched) {
-            log(`Unmatched result: ${tr.testName} (${tr.outcome})`);
+            logger.log(`Unmatched result: ${tr.testName} (${tr.outcome})`);
         }
     }
 
-    log(
+    logger.log(
         `Results: ${summary.passed} passed, ${summary.failed} failed, ${summary.skipped} skipped`,
     );
 }

--- a/src/execution/testRunner.ts
+++ b/src/execution/testRunner.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import { TestTreeProvider, TestTreeNode } from '../ui/testTreeProvider';
 import { runDotnet, getExtraArgs } from '../utils/dotnetCli';
 import { parseTrxFile } from './trxParser';
-import { log, logError } from '../utils/outputChannel';
+import { Logger } from '../utils/logger';
 import { matchAndApplyResults, applyResultState } from './resultMatcher';
 
 const RESULTS_DIR_NAME = '.cursor-test-results';
@@ -61,6 +61,7 @@ export async function executeTests(
     node: TestTreeNode,
     token: vscode.CancellationToken,
     treeProvider: TestTreeProvider,
+    logger: Logger,
 ): Promise<void> {
     if (!node.projectPath || token.isCancellationRequested) {
         return;
@@ -87,13 +88,13 @@ export async function executeTests(
 
     let result: Awaited<ReturnType<typeof runDotnet>>;
     try {
-        result = await runDotnet(args, projectDir, token);
+        result = await runDotnet(args, projectDir, token, logger);
     } catch (err) {
         if (isCancelError(err)) {
             throw err;
         }
 
-        logError(`dotnet test failed to execute for ${node.label}`, err);
+        logger.logError(`dotnet test failed to execute for ${node.label}`, err);
         markRunningNodesAsFailed(node, err, treeProvider);
         fs.rm(trxDir, { recursive: true }).catch(() => {});
         return;
@@ -108,14 +109,14 @@ export async function executeTests(
 
     try {
         const summary = await parseTrxFile(trxPath);
-        matchAndApplyResults(summary, methodNodes, treeProvider);
+        matchAndApplyResults(summary, methodNodes, treeProvider, logger);
     } catch {
-        logError('Could not read TRX results, check output for raw dotnet test output');
+        logger.logError('Could not read TRX results, check output for raw dotnet test output');
         if (result.stdout) {
-            log(result.stdout);
+            logger.log(result.stdout);
         }
         if (result.stderr) {
-            log(result.stderr);
+            logger.log(result.stderr);
         }
 
         if (result.exitCode !== 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,16 @@
 import * as vscode from 'vscode';
 import { CSharpTestController } from './testController';
 import { TestTreeNode } from './ui/testTreeProvider';
-import { disposeChannel, log, showOutput } from './utils/outputChannel';
+import { createLogger, OutputChannelLogger } from './utils/outputChannel';
 
 let controller: CSharpTestController | undefined;
+let logger: OutputChannelLogger | undefined;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-    log('C# Test Explorer activating...');
+    logger = createLogger();
+    logger.log('C# Test Explorer activating...');
 
-    controller = new CSharpTestController(context);
+    controller = new CSharpTestController(context, logger);
     context.subscriptions.push(controller);
 
     // Register commands
@@ -34,7 +36,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }),
 
         vscode.commands.registerCommand('csharpTestExplorer.showOutput', () => {
-            showOutput();
+            logger?.showOutput();
         }),
 
         vscode.commands.registerCommand('csharpTestExplorer.goToTest', (node: TestTreeNode) => {
@@ -62,7 +64,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             clearTimeout(debounceTimer);
         }
         debounceTimer = setTimeout(() => {
-            log('File change detected, re-discovering tests...');
+            logger?.log('File change detected, re-discovering tests...');
             controller?.discoverAllTests();
         }, 3000);
     };
@@ -83,11 +85,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         await controller.discoverAllTests();
     }
 
-    log('C# Test Explorer activated.');
+    logger.log('C# Test Explorer activated.');
 }
 
 export function deactivate(): void {
     controller?.dispose();
     controller = undefined;
-    disposeChannel();
+    logger?.dispose();
+    logger = undefined;
 }

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -9,7 +9,7 @@ import {
     markRunningNodesAsFailed,
 } from './execution/testRunner';
 import { launchDebugSession } from './debug/debugLauncher';
-import { log, logError, showOutput } from './utils/outputChannel';
+import { Logger } from './utils/logger';
 
 export class CSharpTestController implements vscode.Disposable {
     readonly treeProvider: TestTreeProvider;
@@ -23,7 +23,10 @@ export class CSharpTestController implements vscode.Disposable {
     private projects: TestProject[] = [];
     private testsByProject = new Map<string, DiscoveredTest[]>();
 
-    constructor(private readonly context: vscode.ExtensionContext) {
+    constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly logger: Logger,
+    ) {
         this.treeProvider = new TestTreeProvider();
         this.statusBar = new StatusBarManager();
 
@@ -41,7 +44,7 @@ export class CSharpTestController implements vscode.Disposable {
 
     stopRun(): void {
         if (this.activeCts) {
-            log('Cancelling test run...');
+            this.logger.log('Cancelling test run...');
             this.activeCts.cancel();
             this.activeCts.dispose();
             this.activeCts = undefined;
@@ -49,13 +52,13 @@ export class CSharpTestController implements vscode.Disposable {
 
             this.treeProvider.clearRunningStates();
             this.statusBar.updateResults(this.treeProvider.getAllMethodNodes());
-            log('Test run cancelled.');
+            this.logger.log('Test run cancelled.');
         }
     }
 
     async discoverAllTests(token?: vscode.CancellationToken): Promise<void> {
         if (this.isDiscovering) {
-            log('Discovery already in progress, skipping.');
+            this.logger.log('Discovery already in progress, skipping.');
             return;
         }
 
@@ -63,10 +66,10 @@ export class CSharpTestController implements vscode.Disposable {
         this.statusBar.showDiscovering();
 
         try {
-            this.projects = await detectTestProjects();
+            this.projects = await detectTestProjects(this.logger);
 
             if (this.projects.length === 0) {
-                log('No test projects found.');
+                this.logger.log('No test projects found.');
                 this.statusBar.showNoProjects();
                 return;
             }
@@ -79,7 +82,7 @@ export class CSharpTestController implements vscode.Disposable {
                     return;
                 }
 
-                const tests = await discoverTests(project, token);
+                const tests = await discoverTests(project, this.logger, token);
                 this.testsByProject.set(project.csprojPath, tests);
                 totalTests += tests.length;
             }
@@ -87,11 +90,11 @@ export class CSharpTestController implements vscode.Disposable {
             this.treeProvider.buildTree(this.projects, this.testsByProject);
 
             this.statusBar.showDiscovered(totalTests);
-            log(
+            this.logger.log(
                 `Discovery complete: ${totalTests} test(s) across ${this.projects.length} project(s).`,
             );
         } catch (err) {
-            logError('Discovery failed', err);
+            this.logger.logError('Discovery failed', err);
             this.statusBar.showDiscoveryFailed();
         } finally {
             this.isDiscovering = false;
@@ -100,7 +103,7 @@ export class CSharpTestController implements vscode.Disposable {
 
     async runNode(node: TestTreeNode): Promise<void> {
         if (!node.projectPath) {
-            logError('No project path for node');
+            this.logger.logError('No project path for node');
             return;
         }
 
@@ -112,10 +115,10 @@ export class CSharpTestController implements vscode.Disposable {
         this.treeProvider.refresh();
 
         try {
-            await executeTests(node, this.activeCts!.token, this.treeProvider);
+            await executeTests(node, this.activeCts!.token, this.treeProvider, this.logger);
         } catch (err) {
             if (!this.isCancelError(err)) {
-                logError('Run failed', err);
+                this.logger.logError('Run failed', err);
                 markRunningNodesAsFailed(node, err, this.treeProvider);
             }
         } finally {
@@ -139,13 +142,13 @@ export class CSharpTestController implements vscode.Disposable {
                 }
 
                 try {
-                    await executeTests(root, token, this.treeProvider);
+                    await executeTests(root, token, this.treeProvider, this.logger);
                 } catch (err) {
                     if (this.isCancelError(err)) {
                         break;
                     }
 
-                    logError(`Run failed for project: ${root.label}`, err);
+                    this.logger.logError(`Run failed for project: ${root.label}`, err);
                     markRunningNodesAsFailed(root, err, this.treeProvider);
                 }
             }
@@ -156,19 +159,19 @@ export class CSharpTestController implements vscode.Disposable {
 
     async debugNode(node: TestTreeNode): Promise<void> {
         if (!node.projectPath) {
-            logError('No project path for node');
+            this.logger.logError('No project path for node');
             return;
         }
 
         this.startRun();
         this.statusBar.showDebugging();
-        showOutput();
+        this.logger.showOutput();
 
         try {
-            await launchDebugSession(node, this.activeCts!.token);
+            await launchDebugSession(node, this.activeCts!.token, this.logger);
         } catch (err) {
             if (!this.isCancelError(err)) {
-                logError('Debug failed', err);
+                this.logger.logError('Debug failed', err);
             }
         } finally {
             this.finishRun();

--- a/src/utils/dotnetCli.ts
+++ b/src/utils/dotnetCli.ts
@@ -1,6 +1,6 @@
 import { spawn, ChildProcess } from 'child_process';
 import * as vscode from 'vscode';
-import { log, logError } from './outputChannel';
+import { Logger } from './logger';
 
 export interface DotnetResult {
     exitCode: number;
@@ -30,11 +30,12 @@ export function shouldBuildBeforeTest(): boolean {
 export async function runDotnet(
     args: string[],
     cwd: string,
-    token?: vscode.CancellationToken,
+    token: vscode.CancellationToken | undefined,
+    logger: Logger,
     env?: Record<string, string>,
 ): Promise<DotnetResult> {
     const dotnetPath = getDotnetPath();
-    log(`> ${dotnetPath} ${args.join(' ')}  [cwd: ${cwd}]`);
+    logger.log(`> ${dotnetPath} ${args.join(' ')}  [cwd: ${cwd}]`);
 
     return new Promise<DotnetResult>((resolve, reject) => {
         const proc = spawn(dotnetPath, args, {
@@ -66,7 +67,7 @@ export async function runDotnet(
 
         proc.on('error', (err) => {
             onCancel?.dispose();
-            logError('Failed to spawn dotnet', err);
+            logger.logError('Failed to spawn dotnet', err);
             reject(err);
         });
     });
@@ -75,10 +76,11 @@ export async function runDotnet(
 export function spawnDotnet(
     args: string[],
     cwd: string,
+    logger: Logger,
     env?: Record<string, string>,
 ): ChildProcess {
     const dotnetPath = getDotnetPath();
-    log(`> ${dotnetPath} ${args.join(' ')}  [cwd: ${cwd}]`);
+    logger.log(`> ${dotnetPath} ${args.join(' ')}  [cwd: ${cwd}]`);
 
     return spawn(dotnetPath, args, {
         cwd,

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,5 @@
+export interface Logger {
+    log(message: string): void;
+    logError(message: string, error?: unknown): void;
+    showOutput(): void;
+}

--- a/src/utils/outputChannel.ts
+++ b/src/utils/outputChannel.ts
@@ -1,30 +1,61 @@
 import * as vscode from 'vscode';
+import { Logger } from './logger';
 
-let channel: vscode.OutputChannel | undefined;
+export class OutputChannelLogger implements Logger {
+    private readonly channel: vscode.OutputChannel;
 
-export function getOutputChannel(): vscode.OutputChannel {
-    if (!channel) {
-        channel = vscode.window.createOutputChannel('C# Test Explorer');
+    constructor(channel: vscode.OutputChannel) {
+        this.channel = channel;
     }
-    return channel;
+
+    log(message: string): void {
+        this.channel.appendLine(`[${new Date().toLocaleTimeString()}] ${message}`);
+    }
+
+    logError(message: string, error?: unknown): void {
+        const errorMsg = error instanceof Error ? error.message : String(error ?? '');
+        this.channel.appendLine(
+            `[${new Date().toLocaleTimeString()}] ERROR: ${message} ${errorMsg}`,
+        );
+    }
+
+    showOutput(): void {
+        this.channel.show(true);
+    }
+
+    dispose(): void {
+        this.channel.dispose();
+    }
+}
+
+let defaultLogger: OutputChannelLogger | undefined;
+
+function getDefaultLogger(): OutputChannelLogger {
+    if (!defaultLogger) {
+        const channel = vscode.window.createOutputChannel('C# Test Explorer');
+        defaultLogger = new OutputChannelLogger(channel);
+    }
+    return defaultLogger;
+}
+
+export function createLogger(): OutputChannelLogger {
+    const channel = vscode.window.createOutputChannel('C# Test Explorer');
+    return new OutputChannelLogger(channel);
 }
 
 export function log(message: string): void {
-    getOutputChannel().appendLine(`[${new Date().toLocaleTimeString()}] ${message}`);
+    getDefaultLogger().log(message);
 }
 
 export function logError(message: string, error?: unknown): void {
-    const errorMsg = error instanceof Error ? error.message : String(error ?? '');
-    getOutputChannel().appendLine(
-        `[${new Date().toLocaleTimeString()}] ERROR: ${message} ${errorMsg}`,
-    );
+    getDefaultLogger().logError(message, error);
 }
 
 export function showOutput(): void {
-    getOutputChannel().show(true);
+    getDefaultLogger().showOutput();
 }
 
 export function disposeChannel(): void {
-    channel?.dispose();
-    channel = undefined;
+    defaultLogger?.dispose();
+    defaultLogger = undefined;
 }

--- a/test/execution/resultMatcher.test.ts
+++ b/test/execution/resultMatcher.test.ts
@@ -46,14 +46,14 @@ vi.mock('vscode', () => {
     };
 });
 
-vi.mock('../../src/utils/outputChannel', () => ({
-    log: vi.fn(),
-    logError: vi.fn(),
-}));
-
 import { TestTreeProvider, TestTreeNode } from '../../src/ui/testTreeProvider';
 import { applyResultState, matchAndApplyResults } from '../../src/execution/resultMatcher';
 import type { TrxSummary } from '../../src/execution/trxParser';
+import type { Logger } from '../../src/utils/logger';
+
+function createMockLogger(): Logger {
+    return { log: vi.fn(), logError: vi.fn(), showOutput: vi.fn() };
+}
 
 function makeMethodNode(fqn: string, projectPath = '/proj.csproj'): TestTreeNode {
     const node = new TestTreeNode(`method:${projectPath}:${fqn}`, fqn.split('.').pop()!, 'method', fqn);
@@ -105,9 +105,11 @@ describe('applyResultState', () => {
 
 describe('matchAndApplyResults', () => {
     let treeProvider: TestTreeProvider;
+    let mockLogger: Logger;
 
     beforeEach(() => {
         treeProvider = new TestTreeProvider();
+        mockLogger = createMockLogger();
         vi.clearAllMocks();
     });
 
@@ -122,7 +124,7 @@ describe('matchAndApplyResults', () => {
             results: [{ testName: 'MyNamespace.MyClass.TestMethod', outcome: 'Passed', duration: 100 }],
         };
 
-        matchAndApplyResults(summary, [node], treeProvider);
+        matchAndApplyResults(summary, [node], treeProvider, mockLogger);
 
         expect(node.state).toBe('passed');
     });
@@ -138,7 +140,7 @@ describe('matchAndApplyResults', () => {
             results: [{ testName: 'NS.Class.Add(1, 2, 3)', outcome: 'Passed', duration: 50 }],
         };
 
-        matchAndApplyResults(summary, [node], treeProvider);
+        matchAndApplyResults(summary, [node], treeProvider, mockLogger);
 
         expect(node.state).toBe('passed');
     });
@@ -161,7 +163,7 @@ describe('matchAndApplyResults', () => {
             ],
         };
 
-        matchAndApplyResults(summary, [node], treeProvider);
+        matchAndApplyResults(summary, [node], treeProvider, mockLogger);
 
         expect(node.state).toBe('failed');
         expect(node.errorMessage).toBe('Assertion failed');
@@ -178,7 +180,7 @@ describe('matchAndApplyResults', () => {
             results: [{ testName: 'NS.Class.Test1', outcome: 'Failed', duration: 0 }],
         };
 
-        matchAndApplyResults(summary, [node], treeProvider);
+        matchAndApplyResults(summary, [node], treeProvider, mockLogger);
 
         expect(node.state).toBe('failed');
     });
@@ -194,7 +196,7 @@ describe('matchAndApplyResults', () => {
             results: [{ testName: 'NS.Class.Test1', outcome: 'Error', duration: 0 }],
         };
 
-        matchAndApplyResults(summary, [node], treeProvider);
+        matchAndApplyResults(summary, [node], treeProvider, mockLogger);
 
         expect(node.state).toBe('failed');
     });
@@ -210,7 +212,7 @@ describe('matchAndApplyResults', () => {
             results: [{ testName: 'NS.Class.Test1', outcome: 'Timeout', duration: 0 }],
         };
 
-        matchAndApplyResults(summary, [node], treeProvider);
+        matchAndApplyResults(summary, [node], treeProvider, mockLogger);
 
         expect(node.state).toBe('failed');
     });
@@ -226,7 +228,7 @@ describe('matchAndApplyResults', () => {
             results: [{ testName: 'NS.Class.Test1', outcome: 'NotExecuted', duration: 0 }],
         };
 
-        matchAndApplyResults(summary, [node], treeProvider);
+        matchAndApplyResults(summary, [node], treeProvider, mockLogger);
 
         expect(node.state).toBe('skipped');
     });
@@ -246,7 +248,7 @@ describe('matchAndApplyResults', () => {
             ],
         };
 
-        matchAndApplyResults(summary, [node1, node2], treeProvider);
+        matchAndApplyResults(summary, [node1, node2], treeProvider, mockLogger);
 
         expect(node1.state).toBe('passed');
         expect(node2.state).toBe('failed');
@@ -263,7 +265,7 @@ describe('matchAndApplyResults', () => {
             results: [{ testName: 'MyNamespace.Class.TestMethod', outcome: 'Passed', duration: 50 }],
         };
 
-        matchAndApplyResults(summary, [node], treeProvider);
+        matchAndApplyResults(summary, [node], treeProvider, mockLogger);
 
         expect(node.state).toBe('passed');
     });
@@ -279,7 +281,7 @@ describe('matchAndApplyResults', () => {
             results: [{ testName: 'NS.Class.Add(1,2,3)', outcome: 'Passed', duration: 50 }],
         };
 
-        matchAndApplyResults(summary, [node], treeProvider);
+        matchAndApplyResults(summary, [node], treeProvider, mockLogger);
 
         expect(node.state).toBe('passed');
     });
@@ -295,7 +297,7 @@ describe('matchAndApplyResults', () => {
             results: [],
         };
 
-        matchAndApplyResults(summary, [node], treeProvider);
+        matchAndApplyResults(summary, [node], treeProvider, mockLogger);
 
         expect(node.state).toBe('none');
     });
@@ -310,6 +312,6 @@ describe('matchAndApplyResults', () => {
             results: [{ testName: 'NS.Class.Test1', outcome: 'Passed', duration: 50 }],
         };
 
-        expect(() => matchAndApplyResults(summary, [], treeProvider)).not.toThrow();
+        expect(() => matchAndApplyResults(summary, [], treeProvider, mockLogger)).not.toThrow();
     });
 });

--- a/test/runAll.test.ts
+++ b/test/runAll.test.ts
@@ -86,12 +86,6 @@ vi.mock('../src/execution/trxParser', () => ({
     parseTrxFile: (...args: unknown[]) => mockParseTrxFile(...args),
 }));
 
-vi.mock('../src/utils/outputChannel', () => ({
-    log: vi.fn(),
-    logError: vi.fn(),
-    showOutput: vi.fn(),
-}));
-
 vi.mock('fs/promises', () => ({
     mkdir: vi.fn().mockResolvedValue(undefined),
     rm: vi.fn().mockResolvedValue(undefined),
@@ -100,6 +94,11 @@ vi.mock('fs/promises', () => ({
 import { CSharpTestController } from '../src/testController';
 import type { TestProject } from '../src/discovery/projectDetector';
 import type { DiscoveredTest } from '../src/discovery/dotnetDiscoverer';
+import type { Logger } from '../src/utils/logger';
+
+function createMockLogger(): Logger {
+    return { log: vi.fn(), logError: vi.fn(), showOutput: vi.fn() };
+}
 
 function createFakeContext() {
     return { subscriptions: [] } as any;
@@ -109,7 +108,7 @@ function buildControllerWithProjects(
     projects: TestProject[],
     testsByProject: Map<string, DiscoveredTest[]>,
 ): CSharpTestController {
-    const controller = new CSharpTestController(createFakeContext());
+    const controller = new CSharpTestController(createFakeContext(), createMockLogger());
     controller.treeProvider.buildTree(projects, testsByProject);
     return controller;
 }


### PR DESCRIPTION
## Summary
- Extracted a Logger interface (log, logError, showOutput) in src/utils/logger.ts and created an OutputChannelLogger concrete implementation in src/utils/outputChannel.ts
- All services now receive the logger via constructor injection (CSharpTestController) or function parameter instead of importing module-level singletons directly
- Kept the convenience wrapper functions in outputChannel.ts as a fallback for the extension entry point

Closes #17

## Test plan
- [x] All 125 existing tests pass
- [x] TypeScript compilation passes with no errors
- [x] ESLint passes cleanly
- [ ] Verify extension activates and discovers tests normally
- [ ] Verify test execution and debug workflows still work end-to-end


Made with [Cursor](https://cursor.com)