### PR TITLE
fix: handle bare catch blocks and improve error handling

### DIFF
--- a/src/execution/testRunner.ts
+++ b/src/execution/testRunner.ts
@@ -96,7 +96,9 @@ export async function executeTests(
 
         logger.logError(`dotnet test failed to execute for ${node.label}`, err);
         markRunningNodesAsFailed(node, err, treeProvider);
-        fs.rm(trxDir, { recursive: true }).catch(() => {});
+        fs.rm(trxDir, { recursive: true }).catch((cleanupErr) => {
+            logger.logTrace(`Failed to clean up TRX directory ${trxDir}: ${cleanupErr}`);
+        });
         return;
     }
 
@@ -110,8 +112,8 @@ export async function executeTests(
     try {
         const summary = await parseTrxFile(trxPath);
         matchAndApplyResults(summary, methodNodes, treeProvider, logger);
-    } catch {
-        logger.logError('Could not read TRX results, check output for raw dotnet test output');
+    } catch (err) {
+        logger.logError('Could not read TRX results, check output for raw dotnet test output', err);
         if (result.stdout) {
             logger.log(result.stdout);
         }
@@ -133,7 +135,9 @@ export async function executeTests(
         }
     }
 
-    fs.rm(trxDir, { recursive: true }).catch(() => {});
+    fs.rm(trxDir, { recursive: true }).catch((cleanupErr) => {
+        logger.logTrace(`Failed to clean up TRX directory ${trxDir}: ${cleanupErr}`);
+    });
 }
 
 function isCancelError(err: unknown): boolean {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,6 @@
 export interface Logger {
     log(message: string): void;
     logError(message: string, error?: unknown): void;
+    logTrace(message: string): void;
     showOutput(): void;
 }

--- a/src/utils/outputChannel.ts
+++ b/src/utils/outputChannel.ts
@@ -19,6 +19,10 @@ export class OutputChannelLogger implements Logger {
         );
     }
 
+    logTrace(message: string): void {
+        this.channel.appendLine(`[${new Date().toLocaleTimeString()}] TRACE: ${message}`);
+    }
+
     showOutput(): void {
         this.channel.show(true);
     }

--- a/test/execution/resultMatcher.test.ts
+++ b/test/execution/resultMatcher.test.ts
@@ -52,7 +52,7 @@ import type { TrxSummary } from '../../src/execution/trxParser';
 import type { Logger } from '../../src/utils/logger';
 
 function createMockLogger(): Logger {
-    return { log: vi.fn(), logError: vi.fn(), showOutput: vi.fn() };
+    return { log: vi.fn(), logError: vi.fn(), logTrace: vi.fn(), showOutput: vi.fn() };
 }
 
 function makeMethodNode(fqn: string, projectPath = '/proj.csproj'): TestTreeNode {

--- a/test/runAll.test.ts
+++ b/test/runAll.test.ts
@@ -97,7 +97,7 @@ import type { DiscoveredTest } from '../src/discovery/dotnetDiscoverer';
 import type { Logger } from '../src/utils/logger';
 
 function createMockLogger(): Logger {
-    return { log: vi.fn(), logError: vi.fn(), showOutput: vi.fn() };
+    return { log: vi.fn(), logError: vi.fn(), logTrace: vi.fn(), showOutput: vi.fn() };
 }
 
 function createFakeContext() {


### PR DESCRIPTION
## Summary
- Capture the error in the bare catch block in 	estRunner.ts and pass it to logError so TRX parse failures include the underlying cause
- Add logTrace method to the Logger interface and OutputChannelLogger for trace-level diagnostics
- Replace silent catch(() => {}) on TRX directory cleanup with trace-level logging so cleanup failures are visible when debugging
- Update mock loggers in test files to include the new logTrace method

**Note:** The unused lower variable in projectDetector.ts (issue item 3) was already removed in a prior refactor.

Closes #18

## Test plan
- [x] All 125 existing tests pass
- [x] ESLint passes with no errors
- [ ] Manually trigger a test run and verify errors are captured in output
- [ ] Verify trace-level cleanup messages appear in output channel on failure

Made with [Cursor](https://cursor.com)