### PR TITLE
fix: validate project path before test execution and use precise FQN filters

### DIFF
--- a/src/debug/debugLauncher.ts
+++ b/src/debug/debugLauncher.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs/promises';
 import { ChildProcess } from 'child_process';
 import { TestTreeNode } from '../ui/testTreeProvider';
 import { getExtraArgs } from '../utils/dotnetCli';
@@ -14,7 +15,22 @@ export async function launchDebugSession(
     logger: Logger,
 ): Promise<void> {
     if (!node.projectPath) {
-        logger.logError('No project path for node');
+        logger.logError(`No project path for "${node.label}". Try re-discovering tests.`);
+        return;
+    }
+
+    let projectExists = false;
+    try {
+        await fs.access(node.projectPath);
+        projectExists = true;
+    } catch {
+        // file does not exist or is inaccessible
+    }
+
+    if (!projectExists) {
+        logger.logError(
+            `Project file not found: ${node.projectPath}. Re-discover tests to refresh the project list.`,
+        );
         return;
     }
 

--- a/src/execution/testRunner.ts
+++ b/src/execution/testRunner.ts
@@ -15,7 +15,7 @@ export function buildFilterForNode(node: TestTreeNode): string | undefined {
         case 'parameterizedCase':
             return `FullyQualifiedName=${node.fqn}`;
         case 'method':
-            return `FullyQualifiedName~${node.fqn.split('.').pop()}`;
+            return `FullyQualifiedName~${node.fqn}`;
         case 'class':
             return `FullyQualifiedName~${node.fqn}`;
         case 'namespace':
@@ -63,7 +63,29 @@ export async function executeTests(
     treeProvider: TestTreeProvider,
     logger: Logger,
 ): Promise<void> {
-    if (!node.projectPath || token.isCancellationRequested) {
+    if (token.isCancellationRequested) {
+        return;
+    }
+
+    if (!node.projectPath) {
+        const msg = `No project path associated with "${node.label}". Re-discover tests and try again.`;
+        logger.logError(msg);
+        markRunningNodesAsFailed(node, new Error(msg), treeProvider);
+        return;
+    }
+
+    let projectExists = false;
+    try {
+        await fs.access(node.projectPath);
+        projectExists = true;
+    } catch {
+        // file does not exist or is inaccessible
+    }
+
+    if (!projectExists) {
+        const msg = `Project file not found: ${node.projectPath}. Re-discover tests to refresh the project list.`;
+        logger.logError(msg);
+        markRunningNodesAsFailed(node, new Error(msg), treeProvider);
         return;
     }
 

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -103,7 +103,10 @@ export class CSharpTestController implements vscode.Disposable {
 
     async runNode(node: TestTreeNode): Promise<void> {
         if (!node.projectPath) {
-            this.logger.logError('No project path for node');
+            this.logger.logError(`No project path for "${node.label}". Try re-discovering tests.`);
+            vscode.window.showErrorMessage(
+                `Cannot run "${node.label}": no project path found. Try refreshing the test list.`,
+            );
             return;
         }
 
@@ -159,7 +162,10 @@ export class CSharpTestController implements vscode.Disposable {
 
     async debugNode(node: TestTreeNode): Promise<void> {
         if (!node.projectPath) {
-            this.logger.logError('No project path for node');
+            this.logger.logError(`No project path for "${node.label}". Try re-discovering tests.`);
+            vscode.window.showErrorMessage(
+                `Cannot debug "${node.label}": no project path found. Try refreshing the test list.`,
+            );
             return;
         }
 


### PR DESCRIPTION
## Summary
- Validate that .csproj file exists before running/debugging tests, preventing the 'Unable to get working directory for Miscellaneous Files' error when project files are moved or deleted after discovery
- Fix method-level test filter to use the full FQN (FullyQualifiedName~Namespace.Class.Method) instead of just the bare method name, avoiding unintended matches across classes
- Show actionable error messages (both in output channel and VS Code notifications) when projectPath is missing or the .csproj no longer exists, instead of silently failing

Closes #9

## Test plan
- [ ] Discover tests in a workspace with multiple test projects
- [ ] Delete or rename a .csproj after discovery, then attempt to run its tests — verify a clear error message appears instead of the 'Miscellaneous Files' error
- [ ] Run a single test method — verify the filter uses the full FQN (check output channel for the dotnet command)
- [ ] Run all tests — verify all projects execute correctly
- [ ] Debug a test — verify the .csproj validation occurs before debug launch
