### PR TITLE
fix: resolve TRX results not found error on some test runs

### DIFF
--- a/src/execution/testRunner.ts
+++ b/src/execution/testRunner.ts
@@ -9,6 +9,8 @@ import { Logger } from '../utils/logger';
 import { matchAndApplyResults, applyResultState } from './resultMatcher';
 
 const RESULTS_DIR_NAME = '.cursor-test-results';
+const TRX_MAX_RETRIES = 3;
+const TRX_RETRY_DELAY_MS = 500;
 
 export function buildFilterForNode(node: TestTreeNode): string | undefined {
     switch (node.nodeType) {
@@ -128,20 +130,23 @@ export async function executeTests(
         return;
     }
 
-    const trxPath = path.join(trxDir, trxFileName);
     const methodNodes = collectMethodNodes(node);
+    const trxPath = await findTrxFile(trxDir);
+
+    if (!trxPath) {
+        handleMissingTrxFile(result, methodNodes, treeProvider, logger);
+        fs.rm(trxDir, { recursive: true }).catch((cleanupErr) => {
+            logger.logTrace(`Failed to clean up TRX directory ${trxDir}: ${cleanupErr}`);
+        });
+        return;
+    }
 
     try {
         const summary = await parseTrxFile(trxPath);
         matchAndApplyResults(summary, methodNodes, treeProvider, logger);
     } catch (err) {
-        logger.logError('Could not read TRX results, check output for raw dotnet test output', err);
-        if (result.stdout) {
-            logger.log(result.stdout);
-        }
-        if (result.stderr) {
-            logger.log(result.stderr);
-        }
+        logger.logError('Could not parse TRX results, check output for raw dotnet test output', err);
+        dumpDotnetOutput(result, logger);
 
         if (result.exitCode !== 0) {
             for (const m of methodNodes) {
@@ -160,6 +165,103 @@ export async function executeTests(
     fs.rm(trxDir, { recursive: true }).catch((cleanupErr) => {
         logger.logTrace(`Failed to clean up TRX directory ${trxDir}: ${cleanupErr}`);
     });
+}
+
+function handleMissingTrxFile(
+    result: { exitCode: number; stdout: string; stderr: string },
+    methodNodes: TestTreeNode[],
+    treeProvider: TestTreeProvider,
+    logger: Logger,
+): void {
+    if (result.exitCode === 0) {
+        logger.log(
+            'No TRX results file generated. Tests may have been filtered out or skipped.',
+        );
+        for (const m of methodNodes) {
+            if (m.state === 'running') {
+                applyResultState(m, 'skipped', undefined, treeProvider);
+            }
+        }
+    } else {
+        logger.logError(
+            'No TRX results file generated and dotnet test exited with a non-zero code. ' +
+                'Check output for details.',
+        );
+        dumpDotnetOutput(result, logger);
+        for (const m of methodNodes) {
+            if (m.state === 'running') {
+                applyResultState(
+                    m,
+                    'failed',
+                    { errorMessage: 'Test run failed — no TRX results produced. Check C# Test Explorer output.' },
+                    treeProvider,
+                );
+            }
+        }
+    }
+}
+
+function dumpDotnetOutput(
+    result: { stdout: string; stderr: string },
+    logger: Logger,
+): void {
+    if (result.stdout) {
+        logger.log(result.stdout);
+    }
+    if (result.stderr) {
+        logger.log(result.stderr);
+    }
+}
+
+/**
+ * Scans a directory for `.trx` files, retrying with a short delay to handle
+ * the race condition where dotnet test has exited but the TRX file hasn't
+ * been flushed to disk yet.
+ *
+ * Returns the path to the first `.trx` file found, or `undefined` if none
+ * exists after all retries.
+ */
+export async function findTrxFile(
+    trxDir: string,
+    maxRetries: number = TRX_MAX_RETRIES,
+    retryDelayMs: number = TRX_RETRY_DELAY_MS,
+): Promise<string | undefined> {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        if (attempt > 0) {
+            await delay(retryDelayMs);
+        }
+
+        const trxFiles = await findTrxFilesInDir(trxDir);
+        if (trxFiles.length > 0) {
+            return trxFiles[0];
+        }
+    }
+    return undefined;
+}
+
+async function findTrxFilesInDir(dir: string): Promise<string[]> {
+    try {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+        const results: string[] = [];
+
+        for (const entry of entries) {
+            const fullPath = path.join(dir, entry.name);
+            if (entry.isFile() && entry.name.endsWith('.trx')) {
+                results.push(fullPath);
+            } else if (entry.isDirectory()) {
+                const nested = await findTrxFilesInDir(fullPath);
+                results.push(...nested);
+            }
+        }
+
+        return results;
+    } catch {
+        return [];
+    }
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function isCancelError(err: unknown): boolean {

--- a/test/execution/testRunner.test.ts
+++ b/test/execution/testRunner.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { findTrxFile } from '../../src/execution/testRunner';
+
+const TEST_DIR_PREFIX = 'cursor-trx-test-';
+
+let testDir: string;
+
+beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), TEST_DIR_PREFIX));
+});
+
+afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+});
+
+describe('findTrxFile', () => {
+    it('should find a .trx file in the root of the directory', async () => {
+        const trxPath = path.join(testDir, 'results.trx');
+        await fs.writeFile(trxPath, '<TestRun />');
+
+        const result = await findTrxFile(testDir, 0, 0);
+
+        expect(result).toBe(trxPath);
+    });
+
+    it('should find a .trx file with a non-standard name', async () => {
+        const trxPath = path.join(testDir, 'user_machine_2024-01-15.trx');
+        await fs.writeFile(trxPath, '<TestRun />');
+
+        const result = await findTrxFile(testDir, 0, 0);
+
+        expect(result).toBe(trxPath);
+    });
+
+    it('should find a .trx file nested in a subdirectory', async () => {
+        const subDir = path.join(testDir, 'sub');
+        await fs.mkdir(subDir);
+        const trxPath = path.join(subDir, 'results.trx');
+        await fs.writeFile(trxPath, '<TestRun />');
+
+        const result = await findTrxFile(testDir, 0, 0);
+
+        expect(result).toBe(trxPath);
+    });
+
+    it('should return undefined when no .trx files exist', async () => {
+        await fs.writeFile(path.join(testDir, 'readme.txt'), 'not a trx');
+
+        const result = await findTrxFile(testDir, 0, 0);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for an empty directory', async () => {
+        const result = await findTrxFile(testDir, 0, 0);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when directory does not exist', async () => {
+        const nonExistent = path.join(testDir, 'does-not-exist');
+
+        const result = await findTrxFile(nonExistent, 0, 0);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should ignore non-trx files', async () => {
+        await fs.writeFile(path.join(testDir, 'results.xml'), '<xml />');
+        await fs.writeFile(path.join(testDir, 'results.json'), '{}');
+        await fs.writeFile(path.join(testDir, 'log.txt'), 'log');
+
+        const result = await findTrxFile(testDir, 0, 0);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should retry and find a .trx file that appears after a delay', async () => {
+        const trxPath = path.join(testDir, 'results.trx');
+
+        setTimeout(async () => {
+            await fs.writeFile(trxPath, '<TestRun />');
+        }, 100);
+
+        const result = await findTrxFile(testDir, 3, 100);
+
+        expect(result).toBe(trxPath);
+    });
+
+    it('should return undefined after exhausting all retries', async () => {
+        const result = await findTrxFile(testDir, 2, 10);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should return on first attempt when file exists immediately', async () => {
+        const trxPath = path.join(testDir, 'results.trx');
+        await fs.writeFile(trxPath, '<TestRun />');
+
+        const start = Date.now();
+        const result = await findTrxFile(testDir, 3, 500);
+        const elapsed = Date.now() - start;
+
+        expect(result).toBe(trxPath);
+        expect(elapsed).toBeLessThan(200);
+    });
+});

--- a/test/runAll.test.ts
+++ b/test/runAll.test.ts
@@ -89,6 +89,10 @@ vi.mock('../src/execution/trxParser', () => ({
 vi.mock('fs/promises', () => ({
     mkdir: vi.fn().mockResolvedValue(undefined),
     rm: vi.fn().mockResolvedValue(undefined),
+    access: vi.fn().mockResolvedValue(undefined),
+    readdir: vi.fn().mockResolvedValue([
+        { name: 'results.trx', isFile: () => true, isDirectory: () => false },
+    ]),
 }));
 
 import { CSharpTestController } from '../src/testController';


### PR DESCRIPTION
## Summary
- Replace hardcoded TRX file path with a recursive directory scan (indTrxFile) that finds any .trx file in the results directory, handling dotnet SDK versions that write TRX files with non-standard names or into subdirectories
- Add retry logic (3 retries, 500ms delay) to handle the race condition where dotnet test exits before the TRX file is fully flushed to disk
- Handle missing TRX files gracefully: when exit code is 0 (tests filtered out/skipped), mark nodes as skipped; when non-zero, mark as failed with a descriptive error message

Closes #3

## Test plan
- [ ] Run a subset of tests via the Test Explorer and verify results display correctly
- [ ] Run tests that match no filter (all filtered out) and verify nodes show as skipped instead of erroring
- [ ] Verify no regression on normal test runs (all pass, mixed pass/fail)
- [ ] Run the full test suite locally: `npx vitest run` (135 tests pass)
- [ ] Run the linter: `npm run lint` (no errors)


Made with [Cursor](https://cursor.com)