### PR TITLE
feat(ui): collapse tree nodes by default for lazy-load UX

### DIFF
--- a/src/ui/testTreeProvider.ts
+++ b/src/ui/testTreeProvider.ts
@@ -47,7 +47,7 @@ export class TestTreeProvider implements vscode.TreeDataProvider<TestTreeNode> {
     getTreeItem(element: TestTreeNode): vscode.TreeItem {
         const collapsible =
             element.children.length > 0
-                ? vscode.TreeItemCollapsibleState.Expanded
+                ? vscode.TreeItemCollapsibleState.Collapsed
                 : vscode.TreeItemCollapsibleState.None;
 
         const item = new vscode.TreeItem(element.label, collapsible);

--- a/test/ui/testTreeProvider.test.ts
+++ b/test/ui/testTreeProvider.test.ts
@@ -469,3 +469,53 @@ describe('TestTreeProvider.getNodeById', () => {
         expect(found).toBeUndefined();
     });
 });
+
+describe('TestTreeProvider.getTreeItem', () => {
+    it('should return Collapsed state for nodes with children', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);
+        const root = provider.getRoots()[0];
+
+        const treeItem = provider.getTreeItem(root);
+
+        expect(treeItem.collapsibleState).toBe(1); // Collapsed
+    });
+
+    it('should return None state for leaf nodes', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);
+        const method = provider.getAllMethodNodes()[0];
+
+        const treeItem = provider.getTreeItem(method);
+
+        expect(treeItem.collapsibleState).toBe(0); // None
+    });
+
+    it('should set Collapsed state at every non-leaf level', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);
+        const root = provider.getRoots()[0];
+        const nsNode = root.children[0];
+        const classNode = nsNode.children[0];
+
+        expect(provider.getTreeItem(root).collapsibleState).toBe(1); // Collapsed
+        expect(provider.getTreeItem(nsNode).collapsibleState).toBe(1); // Collapsed
+        expect(provider.getTreeItem(classNode).collapsibleState).toBe(1); // Collapsed
+    });
+
+    it('should set id on the tree item', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);
+        const root = provider.getRoots()[0];
+
+        const treeItem = provider.getTreeItem(root);
+
+        expect(treeItem.id).toBe(root.id);
+    });
+
+    it('should show duration in description for method nodes', () => {
+        const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);
+        const method = provider.getAllMethodNodes()[0];
+        method.duration = 42;
+
+        const treeItem = provider.getTreeItem(method);
+
+        expect(treeItem.description).toBe('42ms');
+    });
+});


### PR DESCRIPTION
## Summary
- Changed default tree node collapsible state from Expanded to Collapsed so that only top-level project nodes are visible after discovery, and children are revealed on click.
- Tree state (expanded/collapsed) is automatically preserved across refreshes because TreeItem.id is already set on every node.
- Added 5 tests covering getTreeItem collapsible state behavior.

Closes #6

## Test plan
- [ ] Discover tests in a workspace — verify project nodes appear collapsed
- [ ] Expand a project node — verify namespaces appear, also collapsed
- [ ] Expand namespace then class — verify methods/parameterized cases load correctly
- [ ] Refresh tests — verify previously expanded nodes stay expanded
- [ ] Run all 36 unit tests — verify they pass (
px vitest run test/ui/testTreeProvider.test.ts)

Made with [Cursor](https://cursor.com)