### PR TITLE
feat(ui): add search bar to filter tests by name

### DIFF
--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -54,6 +54,8 @@ src/
 - `csharpTestExplorer.showOutput` — open the output channel
 - `csharpTestExplorer.goToTest` — navigate to a test's source location
 - `csharpTestExplorer.stopRun` — cancel an in-progress test run
+- `csharpTestExplorer.filterTests` — filter the test tree by name (case-insensitive substring)
+- `csharpTestExplorer.clearFilter` — remove the active filter and restore the full tree
 
 ## Keeping This Rule Up-to-Date
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ All commands are available from the **C# Tests** sidebar and the Command Palette
 | Show Output | Open the C# Test Explorer output channel |
 | Go to Test Source | Open the source file at the test method's line |
 | Stop Test Run | Cancel the currently running test execution |
+| Filter Tests | Filter the test tree by name (case-insensitive substring match) |
+| Clear Filter | Remove the active test filter and restore the full tree |
 <!-- AUTO:COMMANDS:END -->
 
 ## How It Works

--- a/package.json
+++ b/package.json
@@ -91,6 +91,20 @@
                 "description": "Cancel the currently running test execution",
                 "category": "C# Test Explorer",
                 "icon": "$(debug-stop)"
+            },
+            {
+                "command": "csharpTestExplorer.filterTests",
+                "title": "Filter Tests",
+                "description": "Filter the test tree by name (case-insensitive substring match)",
+                "category": "C# Test Explorer",
+                "icon": "$(search)"
+            },
+            {
+                "command": "csharpTestExplorer.clearFilter",
+                "title": "Clear Filter",
+                "description": "Remove the active test filter and restore the full tree",
+                "category": "C# Test Explorer",
+                "icon": "$(close)"
             }
         ],
         "menus": {
@@ -114,6 +128,16 @@
                     "command": "csharpTestExplorer.showOutput",
                     "when": "view == csharpTestExplorerView",
                     "group": "navigation@3"
+                },
+                {
+                    "command": "csharpTestExplorer.filterTests",
+                    "when": "view == csharpTestExplorerView && !csharpTestExplorer.isFiltering",
+                    "group": "navigation@4"
+                },
+                {
+                    "command": "csharpTestExplorer.clearFilter",
+                    "when": "view == csharpTestExplorerView && csharpTestExplorer.isFiltering",
+                    "group": "navigation@4"
                 }
             ],
             "view/item/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.commands.registerCommand('csharpTestExplorer.stopRun', () => {
             controller?.stopRun();
         }),
+
+        vscode.commands.registerCommand('csharpTestExplorer.filterTests', async () => {
+            const query = await vscode.window.showInputBox({
+                prompt: 'Filter tests by name',
+                placeHolder: 'Type to filter (case-insensitive substring match)',
+                value: controller?.treeProvider.activeFilter ?? '',
+            });
+            if (query === undefined) {
+                return;
+            }
+            if (query === '') {
+                controller?.clearFilter();
+            } else {
+                controller?.applyFilter(query);
+            }
+        }),
+
+        vscode.commands.registerCommand('csharpTestExplorer.clearFilter', () => {
+            controller?.clearFilter();
+        }),
     );
 
     // File watcher: re-discover when .cs or .csproj files change

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -23,6 +23,8 @@ export class CSharpTestController implements vscode.Disposable {
     private projects: TestProject[] = [];
     private testsByProject = new Map<string, DiscoveredTest[]>();
 
+    private readonly treeView: vscode.TreeView<TestTreeNode>;
+
     constructor(
         private readonly context: vscode.ExtensionContext,
         private readonly logger: Logger,
@@ -30,16 +32,28 @@ export class CSharpTestController implements vscode.Disposable {
         this.treeProvider = new TestTreeProvider();
         this.statusBar = new StatusBarManager();
 
-        const treeView = vscode.window.createTreeView('csharpTestExplorerView', {
+        this.treeView = vscode.window.createTreeView('csharpTestExplorerView', {
             treeDataProvider: this.treeProvider,
             showCollapseAll: true,
         });
 
-        this.disposables.push(treeView, this.statusBar, this.treeProvider);
+        this.disposables.push(this.treeView, this.statusBar, this.treeProvider);
     }
 
     get running(): boolean {
         return this.isRunning;
+    }
+
+    applyFilter(query: string): void {
+        this.treeProvider.setFilter(query);
+        this.treeView.message = `Filter: "${query}"`;
+        vscode.commands.executeCommand('setContext', 'csharpTestExplorer.isFiltering', true);
+    }
+
+    clearFilter(): void {
+        this.treeProvider.clearFilter();
+        this.treeView.message = undefined;
+        vscode.commands.executeCommand('setContext', 'csharpTestExplorer.isFiltering', false);
     }
 
     stopRun(): void {

--- a/src/ui/testTreeProvider.ts
+++ b/src/ui/testTreeProvider.ts
@@ -43,12 +43,31 @@ export class TestTreeProvider implements vscode.TreeDataProvider<TestTreeNode> {
 
     private roots: TestTreeNode[] = [];
     private allNodes = new Map<string, TestTreeNode>();
+    private filterQuery = '';
+
+    get activeFilter(): string {
+        return this.filterQuery;
+    }
+
+    setFilter(query: string): void {
+        this.filterQuery = query.toLowerCase();
+        this._onDidChangeTreeData.fire();
+    }
+
+    clearFilter(): void {
+        this.filterQuery = '';
+        this._onDidChangeTreeData.fire();
+    }
 
     getTreeItem(element: TestTreeNode): vscode.TreeItem {
-        const collapsible =
-            element.children.length > 0
-                ? vscode.TreeItemCollapsibleState.Collapsed
-                : vscode.TreeItemCollapsibleState.None;
+        const hasVisibleChildren = this.filterQuery
+            ? element.children.some((c) => this.subtreeMatchesFilter(c))
+            : element.children.length > 0;
+        const collapsible = hasVisibleChildren
+            ? this.filterQuery
+                ? vscode.TreeItemCollapsibleState.Expanded
+                : vscode.TreeItemCollapsibleState.Collapsed
+            : vscode.TreeItemCollapsibleState.None;
 
         const item = new vscode.TreeItem(element.label, collapsible);
         item.id = element.id;
@@ -88,10 +107,11 @@ export class TestTreeProvider implements vscode.TreeDataProvider<TestTreeNode> {
     }
 
     getChildren(element?: TestTreeNode): TestTreeNode[] {
-        if (!element) {
-            return this.roots;
+        const children = element ? [...element.children] : this.roots;
+        if (!this.filterQuery) {
+            return children;
         }
-        return [...element.children];
+        return children.filter((child) => this.subtreeMatchesFilter(child));
     }
 
     getParent(element: TestTreeNode): TestTreeNode | undefined {
@@ -332,6 +352,16 @@ export class TestTreeProvider implements vscode.TreeDataProvider<TestTreeNode> {
 
     getNodeById(id: string): TestTreeNode | undefined {
         return this.allNodes.get(id);
+    }
+
+    private subtreeMatchesFilter(node: TestTreeNode): boolean {
+        if (node.fqn.toLowerCase().includes(this.filterQuery)) {
+            return true;
+        }
+        if (node.label.toLowerCase().includes(this.filterQuery)) {
+            return true;
+        }
+        return node.children.some((child) => this.subtreeMatchesFilter(child));
     }
 
     private propagateStateUp(node: TestTreeNode): void {

--- a/test/ui/testTreeProvider.test.ts
+++ b/test/ui/testTreeProvider.test.ts
@@ -470,6 +470,177 @@ describe('TestTreeProvider.getNodeById', () => {
     });
 });
 
+describe('TestTreeProvider filtering', () => {
+    it('should return only matching methods when filter is set', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'LoginTest'),
+            makeTest('NS', 'Cls', 'LogoutTest'),
+            makeTest('NS', 'Cls', 'SignUpTest'),
+        ]);
+
+        provider.setFilter('login');
+
+        const roots = provider.getChildren();
+        expect(roots).toHaveLength(1);
+        const ns = provider.getChildren(roots[0]);
+        const cls = provider.getChildren(ns[0]);
+        const methods = provider.getChildren(cls[0]);
+        expect(methods).toHaveLength(1);
+        expect(methods[0].fqn).toBe('NS.Cls.LoginTest');
+    });
+
+    it('should be case-insensitive', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'LoginTest'),
+            makeTest('NS', 'Cls', 'OtherTest'),
+        ]);
+
+        provider.setFilter('LOGIN');
+
+        const roots = provider.getChildren();
+        const ns = provider.getChildren(roots[0]);
+        const cls = provider.getChildren(ns[0]);
+        const methods = provider.getChildren(cls[0]);
+        expect(methods).toHaveLength(1);
+        expect(methods[0].fqn).toBe('NS.Cls.LoginTest');
+    });
+
+    it('should match on partial name (substring)', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'CalculateTotal'),
+            makeTest('NS', 'Cls', 'CalculateDiscount'),
+            makeTest('NS', 'Cls', 'ValidateInput'),
+        ]);
+
+        provider.setFilter('calc');
+
+        const roots = provider.getChildren();
+        const ns = provider.getChildren(roots[0]);
+        const cls = provider.getChildren(ns[0]);
+        const methods = provider.getChildren(cls[0]);
+        expect(methods).toHaveLength(2);
+    });
+
+    it('should match on fully qualified name', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('App.Services', 'OrderService', 'PlaceOrder'),
+            makeTest('App.Utils', 'Helper', 'DoStuff'),
+        ]);
+
+        provider.setFilter('services');
+
+        const roots = provider.getChildren();
+        const namespaces = provider.getChildren(roots[0]);
+        expect(namespaces).toHaveLength(1);
+        expect(namespaces[0].fqn).toBe('App.Services');
+    });
+
+    it('should show ancestor chain for matching leaf nodes', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('Deep.Namespace', 'SomeClass', 'TargetTest'),
+            makeTest('Other', 'OtherClass', 'OtherTest'),
+        ]);
+
+        provider.setFilter('target');
+
+        const roots = provider.getChildren();
+        expect(roots).toHaveLength(1);
+        const ns = provider.getChildren(roots[0]);
+        expect(ns).toHaveLength(1);
+        expect(ns[0].fqn).toBe('Deep.Namespace');
+    });
+
+    it('should restore full tree when filter is cleared', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Test1'),
+            makeTest('NS', 'Cls', 'Test2'),
+            makeTest('NS', 'Cls', 'Test3'),
+        ]);
+
+        provider.setFilter('Test1');
+        provider.clearFilter();
+
+        const roots = provider.getChildren();
+        const ns = provider.getChildren(roots[0]);
+        const cls = provider.getChildren(ns[0]);
+        const methods = provider.getChildren(cls[0]);
+        expect(methods).toHaveLength(3);
+    });
+
+    it('should return empty tree when no tests match', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Test1'),
+        ]);
+
+        provider.setFilter('nonexistent');
+
+        const roots = provider.getChildren();
+        expect(roots).toHaveLength(0);
+    });
+
+    it('should expose the active filter via activeFilter getter', () => {
+        const provider = new TestTreeProvider();
+
+        expect(provider.activeFilter).toBe('');
+
+        provider.setFilter('Hello');
+        expect(provider.activeFilter).toBe('hello');
+
+        provider.clearFilter();
+        expect(provider.activeFilter).toBe('');
+    });
+
+    it('should filter parameterized cases by their display name', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(1,2)',
+                displayName: 'Add(1,2)',
+                parameters: '1,2',
+            }),
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(3,4)',
+                displayName: 'Add(3,4)',
+                parameters: '3,4',
+            }),
+            makeTest('NS', 'Cls', 'Subtract', {
+                fullyQualifiedName: 'NS.Cls.Subtract(5,3)',
+                displayName: 'Subtract(5,3)',
+                parameters: '5,3',
+            }),
+        ]);
+
+        provider.setFilter('add');
+
+        const roots = provider.getChildren();
+        const ns = provider.getChildren(roots[0]);
+        const cls = provider.getChildren(ns[0]);
+        expect(cls[0].children.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should expand filtered nodes instead of collapsing them', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Test1'),
+        ]);
+
+        provider.setFilter('test1');
+        const root = provider.getChildren()[0];
+        const treeItem = provider.getTreeItem(root);
+
+        expect(treeItem.collapsibleState).toBe(2); // Expanded
+    });
+
+    it('should keep Collapsed state when no filter is active', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Test1'),
+        ]);
+
+        const root = provider.getChildren()[0];
+        const treeItem = provider.getTreeItem(root);
+
+        expect(treeItem.collapsibleState).toBe(1); // Collapsed
+    });
+});
+
 describe('TestTreeProvider.getTreeItem', () => {
     it('should return Collapsed state for nodes with children', () => {
         const provider = buildSingleProjectTree('Proj', [makeTest('NS', 'Cls', 'Test1')]);


### PR DESCRIPTION
## Summary
- Adds a search/filter feature to the Test Explorer panel via a search icon in the view title bar
- Typing a query filters the tree to show only tests whose fully qualified name or label matches (case-insensitive substring match)
- Clearing the filter restores the full tree; filtered nodes are auto-expanded for visibility

Closes #2

## Test plan
- [ ] Click the search icon in the Test Explorer title bar and enter a partial test name
- [ ] Verify only matching tests (and their ancestor chain) are shown
- [ ] Verify filtering is case-insensitive
- [ ] Clear the filter via the X icon and verify the full tree is restored
- [ ] Verify 11 new unit tests pass (`npx vitest run test/ui/testTreeProvider.test.ts`)

Made with [Cursor](https://cursor.com)