### PR TITLE
feat(execution): support running multiple selected tests at once

### DIFF
--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -49,7 +49,8 @@ src/
 ## Commands (registered in extension.ts)
 - `csharpTestExplorer.refreshTests` — re-discover all tests
 - `csharpTestExplorer.runAll` — run every discovered test
-- `csharpTestExplorer.runTest` — run a specific tree node
+- `csharpTestExplorer.runTest` — run a specific tree node (supports multi-select via context menu)
+- `csharpTestExplorer.runSelected` — run all currently selected tests in the tree
 - `csharpTestExplorer.debugTest` — debug a specific tree node
 - `csharpTestExplorer.showOutput` — open the output channel
 - `csharpTestExplorer.goToTest` — navigate to a test's source location

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ All commands are available from the **C# Tests** sidebar and the Command Palette
 | Go to Test Source | Open the source file at the test method's line |
 | Stop Test Run | Cancel the currently running test execution |
 | Filter Tests | Filter the test tree by name (case-insensitive substring match) |
+| Run Selected Tests | Run all currently selected tests in the tree |
 | Clear Filter | Remove the active test filter and restore the full tree |
 <!-- AUTO:COMMANDS:END -->
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,13 @@
                 "icon": "$(search)"
             },
             {
+                "command": "csharpTestExplorer.runSelected",
+                "title": "Run Selected Tests",
+                "description": "Run all currently selected tests in the tree",
+                "category": "C# Test Explorer",
+                "icon": "$(run-all)"
+            },
+            {
                 "command": "csharpTestExplorer.clearFilter",
                 "title": "Clear Filter",
                 "description": "Remove the active test filter and restore the full tree",
@@ -143,22 +150,32 @@
             "view/item/context": [
                 {
                     "command": "csharpTestExplorer.runTest",
-                    "when": "view == csharpTestExplorerView",
+                    "when": "view == csharpTestExplorerView && !listMultiSelection",
+                    "group": "inline@1"
+                },
+                {
+                    "command": "csharpTestExplorer.runSelected",
+                    "when": "view == csharpTestExplorerView && listMultiSelection",
                     "group": "inline@1"
                 },
                 {
                     "command": "csharpTestExplorer.debugTest",
-                    "when": "view == csharpTestExplorerView",
+                    "when": "view == csharpTestExplorerView && !listMultiSelection",
                     "group": "inline@2"
                 },
                 {
                     "command": "csharpTestExplorer.runTest",
-                    "when": "view == csharpTestExplorerView",
+                    "when": "view == csharpTestExplorerView && !listMultiSelection",
+                    "group": "1_run@1"
+                },
+                {
+                    "command": "csharpTestExplorer.runSelected",
+                    "when": "view == csharpTestExplorerView && listMultiSelection",
                     "group": "1_run@1"
                 },
                 {
                     "command": "csharpTestExplorer.debugTest",
-                    "when": "view == csharpTestExplorerView",
+                    "when": "view == csharpTestExplorerView && !listMultiSelection",
                     "group": "1_run@2"
                 },
                 {

--- a/src/execution/testRunner.ts
+++ b/src/execution/testRunner.ts
@@ -46,7 +46,14 @@ export function markRunningNodesAsFailed(
     err: unknown,
     treeProvider: TestTreeProvider,
 ): void {
-    const methodNodes = collectMethodNodes(node);
+    markMethodNodesFailed(collectMethodNodes(node), err, treeProvider);
+}
+
+function markMethodNodesFailed(
+    methodNodes: TestTreeNode[],
+    err: unknown,
+    treeProvider: TestTreeProvider,
+): void {
     for (const m of methodNodes) {
         if (m.state === 'running') {
             applyResultState(
@@ -76,31 +83,131 @@ export async function executeTests(
         return;
     }
 
+    const filter = buildFilterForNode(node);
+    const methodNodes = collectMethodNodes(node);
+
+    await executeTestRun(
+        node.projectPath,
+        node.label,
+        filter,
+        methodNodes,
+        token,
+        treeProvider,
+        logger,
+    );
+}
+
+export function buildFilterForNodes(nodes: TestTreeNode[]): string | undefined {
+    const expressions: string[] = [];
+
+    for (const node of nodes) {
+        const filter = buildFilterForNode(node);
+        if (!filter) {
+            return undefined;
+        }
+        expressions.push(filter);
+    }
+
+    if (expressions.length === 0) {
+        return undefined;
+    }
+
+    return expressions.length === 1
+        ? expressions[0]
+        : expressions.map((e) => `(${e})`).join(' | ');
+}
+
+export function collectAllMethodNodes(nodes: TestTreeNode[]): TestTreeNode[] {
+    const result: TestTreeNode[] = [];
+    const seen = new Set<string>();
+
+    for (const node of nodes) {
+        for (const m of collectMethodNodes(node)) {
+            if (!seen.has(m.id)) {
+                seen.add(m.id);
+                result.push(m);
+            }
+        }
+    }
+
+    return result;
+}
+
+export function groupNodesByProject(nodes: TestTreeNode[]): Map<string, TestTreeNode[]> {
+    const grouped = new Map<string, TestTreeNode[]>();
+
+    for (const node of nodes) {
+        const projectPath = node.projectPath;
+        if (!projectPath) {
+            continue;
+        }
+
+        const list = grouped.get(projectPath) ?? [];
+        list.push(node);
+        grouped.set(projectPath, list);
+    }
+
+    return grouped;
+}
+
+export async function executeTestsForNodes(
+    nodes: TestTreeNode[],
+    token: vscode.CancellationToken,
+    treeProvider: TestTreeProvider,
+    logger: Logger,
+): Promise<void> {
+    const byProject = groupNodesByProject(nodes);
+
+    for (const [projectPath, projectNodes] of byProject) {
+        if (token.isCancellationRequested) {
+            break;
+        }
+
+        const filter = buildFilterForNodes(projectNodes);
+        const methodNodes = collectAllMethodNodes(projectNodes);
+        const label = projectNodes.map((n) => n.label).join(', ');
+
+        await executeTestRun(projectPath, label, filter, methodNodes, token, treeProvider, logger);
+    }
+}
+
+async function executeTestRun(
+    projectPath: string,
+    label: string,
+    filter: string | undefined,
+    methodNodes: TestTreeNode[],
+    token: vscode.CancellationToken,
+    treeProvider: TestTreeProvider,
+    logger: Logger,
+): Promise<void> {
+    if (token.isCancellationRequested) {
+        return;
+    }
+
     let projectExists = false;
     try {
-        await fs.access(node.projectPath);
+        await fs.access(projectPath);
         projectExists = true;
     } catch {
         // file does not exist or is inaccessible
     }
 
     if (!projectExists) {
-        const msg = `Project file not found: ${node.projectPath}. Re-discover tests to refresh the project list.`;
+        const msg = `Project file not found: ${projectPath}. Re-discover tests to refresh the project list.`;
         logger.logError(msg);
-        markRunningNodesAsFailed(node, new Error(msg), treeProvider);
+        markMethodNodesFailed(methodNodes, new Error(msg), treeProvider);
         return;
     }
 
-    const projectDir = path.dirname(node.projectPath);
+    const projectDir = path.dirname(projectPath);
     const trxDir = path.join(os.tmpdir(), RESULTS_DIR_NAME, Date.now().toString());
     await fs.mkdir(trxDir, { recursive: true });
     const trxFileName = 'results.trx';
 
-    const args = ['test', node.projectPath, '--no-restore'];
+    const args = ['test', projectPath, '--no-restore'];
     args.push('--logger', `trx;LogFileName=${trxFileName}`);
     args.push('--results-directory', trxDir);
 
-    const filter = buildFilterForNode(node);
     if (filter) {
         args.push('--filter', filter);
     }
@@ -118,8 +225,8 @@ export async function executeTests(
             throw err;
         }
 
-        logger.logError(`dotnet test failed to execute for ${node.label}`, err);
-        markRunningNodesAsFailed(node, err, treeProvider);
+        logger.logError(`dotnet test failed to execute for ${label}`, err);
+        markMethodNodesFailed(methodNodes, err, treeProvider);
         fs.rm(trxDir, { recursive: true }).catch((cleanupErr) => {
             logger.logTrace(`Failed to clean up TRX directory ${trxDir}: ${cleanupErr}`);
         });
@@ -130,7 +237,6 @@ export async function executeTests(
         return;
     }
 
-    const methodNodes = collectMethodNodes(node);
     const trxPath = await findTrxFile(trxDir);
 
     if (!trxPath) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,11 +23,27 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             controller?.runAll();
         }),
 
-        vscode.commands.registerCommand('csharpTestExplorer.runTest', (node: TestTreeNode) => {
-            if (node) {
-                controller?.runNode(node);
-            }
-        }),
+        vscode.commands.registerCommand(
+            'csharpTestExplorer.runTest',
+            (node: TestTreeNode, selectedNodes?: TestTreeNode[]) => {
+                if (selectedNodes && selectedNodes.length > 1) {
+                    controller?.runNodes(selectedNodes);
+                } else if (node) {
+                    controller?.runNode(node);
+                }
+            },
+        ),
+
+        vscode.commands.registerCommand(
+            'csharpTestExplorer.runSelected',
+            (_node?: TestTreeNode, selectedNodes?: TestTreeNode[]) => {
+                if (selectedNodes && selectedNodes.length > 0) {
+                    controller?.runNodes(selectedNodes);
+                } else {
+                    controller?.runSelected();
+                }
+            },
+        ),
 
         vscode.commands.registerCommand('csharpTestExplorer.debugTest', (node: TestTreeNode) => {
             if (node) {

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -5,7 +5,9 @@ import { TestTreeProvider, TestTreeNode } from './ui/testTreeProvider';
 import { StatusBarManager } from './ui/statusBarManager';
 import {
     executeTests,
+    executeTestsForNodes,
     collectMethodNodes,
+    collectAllMethodNodes,
     markRunningNodesAsFailed,
 } from './execution/testRunner';
 import { launchDebugSession } from './debug/debugLauncher';
@@ -35,6 +37,7 @@ export class CSharpTestController implements vscode.Disposable {
         this.treeView = vscode.window.createTreeView('csharpTestExplorerView', {
             treeDataProvider: this.treeProvider,
             showCollapseAll: true,
+            canSelectMany: true,
         });
 
         this.disposables.push(this.treeView, this.statusBar, this.treeProvider);
@@ -172,6 +175,51 @@ export class CSharpTestController implements vscode.Disposable {
         } finally {
             this.finishRun();
         }
+    }
+
+    async runNodes(nodes: readonly TestTreeNode[]): Promise<void> {
+        const validNodes = nodes.filter((n) => n.projectPath);
+        if (validNodes.length === 0) {
+            vscode.window.showErrorMessage(
+                'No valid test nodes selected. Try refreshing the test list.',
+            );
+            return;
+        }
+
+        this.startRun();
+        const methodNodes = collectAllMethodNodes(validNodes);
+        for (const m of methodNodes) {
+            m.state = 'running';
+        }
+        this.treeProvider.refresh();
+
+        try {
+            await executeTestsForNodes(validNodes, this.activeCts!.token, this.treeProvider, this.logger);
+        } catch (err) {
+            if (!this.isCancelError(err)) {
+                this.logger.logError('Run failed', err);
+                for (const node of validNodes) {
+                    markRunningNodesAsFailed(node, err, this.treeProvider);
+                }
+            }
+        } finally {
+            this.finishRun();
+        }
+    }
+
+    async runSelected(): Promise<void> {
+        const selection = this.treeView.selection;
+        if (selection.length === 0) {
+            vscode.window.showInformationMessage('No tests selected. Select tests in the tree first.');
+            return;
+        }
+
+        if (selection.length === 1) {
+            await this.runNode(selection[0]);
+            return;
+        }
+
+        await this.runNodes(selection);
     }
 
     async debugNode(node: TestTreeNode): Promise<void> {

--- a/test/execution/testRunner.test.ts
+++ b/test/execution/testRunner.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { findTrxFile } from '../../src/execution/testRunner';
+import {
+    findTrxFile,
+    buildFilterForNode,
+    buildFilterForNodes,
+    collectAllMethodNodes,
+    groupNodesByProject,
+} from '../../src/execution/testRunner';
+import { TestTreeNode } from '../../src/ui/testTreeProvider';
 
 const TEST_DIR_PREFIX = 'cursor-trx-test-';
 
@@ -106,5 +113,224 @@ describe('findTrxFile', () => {
 
         expect(result).toBe(trxPath);
         expect(elapsed).toBeLessThan(200);
+    });
+});
+
+function makeNode(
+    nodeType: 'project' | 'namespace' | 'class' | 'method' | 'parameterizedCase',
+    fqn: string,
+    projectPath?: string,
+): TestTreeNode {
+    const node = new TestTreeNode(`${nodeType}:${fqn}`, fqn.split('.').pop()!, nodeType, fqn);
+    node.projectPath = projectPath;
+    return node;
+}
+
+describe('buildFilterForNode', () => {
+    it('should return FullyQualifiedName= for a method node', () => {
+        const node = makeNode('method', 'NS.Class.TestMethod');
+
+        const result = buildFilterForNode(node);
+
+        expect(result).toBe('FullyQualifiedName~NS.Class.TestMethod');
+    });
+
+    it('should return FullyQualifiedName= for a parameterizedCase node', () => {
+        const node = makeNode('parameterizedCase', 'NS.Class.Add(1,2)');
+
+        const result = buildFilterForNode(node);
+
+        expect(result).toBe('FullyQualifiedName=NS.Class.Add(1,2)');
+    });
+
+    it('should return FullyQualifiedName~ for a class node', () => {
+        const node = makeNode('class', 'NS.CalculatorTests');
+
+        const result = buildFilterForNode(node);
+
+        expect(result).toBe('FullyQualifiedName~NS.CalculatorTests');
+    });
+
+    it('should return FullyQualifiedName~ for a namespace node', () => {
+        const node = makeNode('namespace', 'MyApp.Tests');
+
+        const result = buildFilterForNode(node);
+
+        expect(result).toBe('FullyQualifiedName~MyApp.Tests');
+    });
+
+    it('should return undefined for a project node', () => {
+        const node = makeNode('project', 'MyProject');
+
+        const result = buildFilterForNode(node);
+
+        expect(result).toBeUndefined();
+    });
+});
+
+describe('buildFilterForNodes', () => {
+    it('should return single filter expression for one node', () => {
+        const nodes = [makeNode('method', 'NS.Class.TestA')];
+
+        const result = buildFilterForNodes(nodes);
+
+        expect(result).toBe('FullyQualifiedName~NS.Class.TestA');
+    });
+
+    it('should combine multiple method filters with OR logic', () => {
+        const nodes = [
+            makeNode('method', 'NS.Class.TestA'),
+            makeNode('method', 'NS.Class.TestB'),
+        ];
+
+        const result = buildFilterForNodes(nodes);
+
+        expect(result).toBe(
+            '(FullyQualifiedName~NS.Class.TestA) | (FullyQualifiedName~NS.Class.TestB)',
+        );
+    });
+
+    it('should combine mixed node types with OR logic', () => {
+        const nodes = [
+            makeNode('method', 'NS.Class.TestA'),
+            makeNode('class', 'NS.OtherClass'),
+        ];
+
+        const result = buildFilterForNodes(nodes);
+
+        expect(result).toBe(
+            '(FullyQualifiedName~NS.Class.TestA) | (FullyQualifiedName~NS.OtherClass)',
+        );
+    });
+
+    it('should return undefined if any node is a project', () => {
+        const nodes = [
+            makeNode('method', 'NS.Class.TestA'),
+            makeNode('project', 'MyProject'),
+        ];
+
+        const result = buildFilterForNodes(nodes);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for an empty array', () => {
+        const result = buildFilterForNodes([]);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should combine three filters correctly', () => {
+        const nodes = [
+            makeNode('method', 'NS.A.Test1'),
+            makeNode('method', 'NS.B.Test2'),
+            makeNode('class', 'NS.C'),
+        ];
+
+        const result = buildFilterForNodes(nodes);
+
+        expect(result).toBe(
+            '(FullyQualifiedName~NS.A.Test1) | (FullyQualifiedName~NS.B.Test2) | (FullyQualifiedName~NS.C)',
+        );
+    });
+});
+
+describe('collectAllMethodNodes', () => {
+    it('should collect method nodes from multiple top-level nodes', () => {
+        const method1 = makeNode('method', 'NS.A.Test1');
+        const method2 = makeNode('method', 'NS.B.Test2');
+
+        const result = collectAllMethodNodes([method1, method2]);
+
+        expect(result).toHaveLength(2);
+        expect(result).toContain(method1);
+        expect(result).toContain(method2);
+    });
+
+    it('should deduplicate method nodes that appear under multiple parents', () => {
+        const method = makeNode('method', 'NS.A.Test1');
+        const classNode = makeNode('class', 'NS.A');
+        classNode.addChild(method);
+
+        const result = collectAllMethodNodes([classNode, method]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toBe(method);
+    });
+
+    it('should collect nested method nodes from class and namespace nodes', () => {
+        const method1 = makeNode('method', 'NS.A.Test1');
+        const method2 = makeNode('method', 'NS.A.Test2');
+        const classNode = makeNode('class', 'NS.A');
+        classNode.addChild(method1);
+        classNode.addChild(method2);
+
+        const result = collectAllMethodNodes([classNode]);
+
+        expect(result).toHaveLength(2);
+    });
+
+    it('should return empty array for empty input', () => {
+        const result = collectAllMethodNodes([]);
+
+        expect(result).toHaveLength(0);
+    });
+
+    it('should include parameterizedCase nodes', () => {
+        const case1 = makeNode('parameterizedCase', 'NS.A.Add(1,2)');
+        const case2 = makeNode('parameterizedCase', 'NS.A.Add(3,4)');
+        const methodNode = makeNode('method', 'NS.A.Add');
+        methodNode.addChild(case1);
+        methodNode.addChild(case2);
+
+        const result = collectAllMethodNodes([methodNode]);
+
+        expect(result).toHaveLength(2);
+        expect(result).toContain(case1);
+        expect(result).toContain(case2);
+    });
+});
+
+describe('groupNodesByProject', () => {
+    it('should group nodes by project path', () => {
+        const node1 = makeNode('method', 'NS.A.Test1', '/path/to/projectA.csproj');
+        const node2 = makeNode('method', 'NS.B.Test2', '/path/to/projectB.csproj');
+        const node3 = makeNode('method', 'NS.A.Test3', '/path/to/projectA.csproj');
+
+        const result = groupNodesByProject([node1, node2, node3]);
+
+        expect(result.size).toBe(2);
+        expect(result.get('/path/to/projectA.csproj')).toHaveLength(2);
+        expect(result.get('/path/to/projectB.csproj')).toHaveLength(1);
+    });
+
+    it('should skip nodes without project path', () => {
+        const node1 = makeNode('method', 'NS.A.Test1', '/path/to/project.csproj');
+        const node2 = makeNode('method', 'NS.B.Test2');
+
+        const result = groupNodesByProject([node1, node2]);
+
+        expect(result.size).toBe(1);
+        expect(result.get('/path/to/project.csproj')).toHaveLength(1);
+    });
+
+    it('should return empty map for empty input', () => {
+        const result = groupNodesByProject([]);
+
+        expect(result.size).toBe(0);
+    });
+
+    it('should put all nodes in one group when they share the same project', () => {
+        const projectPath = '/path/to/project.csproj';
+        const nodes = [
+            makeNode('method', 'NS.A.Test1', projectPath),
+            makeNode('method', 'NS.A.Test2', projectPath),
+            makeNode('class', 'NS.B', projectPath),
+        ];
+
+        const result = groupNodesByProject(nodes);
+
+        expect(result.size).toBe(1);
+        expect(result.get(projectPath)).toHaveLength(3);
     });
 });


### PR DESCRIPTION
## Summary
- Enable multi-select in the Test Explorer tree view (Ctrl+Click / Shift+Click) and run all selected tests in a single combined execution
- Refactor test execution into a shared executeTestRun helper, add uildFilterForNodes (OR-combined filters), collectAllMethodNodes (deduplicated), and groupNodesByProject to support multi-node runs
- Add unSelected command and context-aware menu entries that swap between single-run and multi-run based on selection

Closes #5

## Test plan
- [x] All 171 existing tests pass
- [x] 25 new unit tests for uildFilterForNode, uildFilterForNodes, collectAllMethodNodes, and groupNodesByProject
- [ ] Manual: multi-select test nodes in tree, right-click -> Run Selected Tests
- [ ] Manual: single-select still works as before via inline play button
- [ ] Manual: selecting nodes from different projects runs each project separately


Made with [Cursor](https://cursor.com)