### PR TITLE
fix: match TestCaseSource results to discovered test nodes

### DIFF
--- a/src/discovery/dotnetDiscoverer.ts
+++ b/src/discovery/dotnetDiscoverer.ts
@@ -5,6 +5,7 @@ import { TestProject } from './projectDetector';
 import {
     TEST_ATTRIBUTE_REGEX,
     PARAMETERIZED_ATTRIBUTE_REGEX,
+    DYNAMIC_SOURCE_ATTRIBUTE_REGEX,
     CLASS_REGEX,
     METHOD_REGEX,
     NAMESPACE_REGEX,
@@ -21,6 +22,7 @@ export interface DiscoveredTest {
     sourceUri: vscode.Uri;
     sourceLine: number;
     parameters?: string;
+    hasDynamicSource?: boolean;
 }
 
 export async function discoverTests(
@@ -68,6 +70,7 @@ function parseTestMethods(
     let currentNamespace = '';
     let currentClass = '';
     let nextMethodIsTest = false;
+    let nextMethodIsDynamicSource = false;
     const pendingParams: string[] = [];
     let braceDepth = 0;
     const classStack: { name: string; depth: number }[] = [];
@@ -96,6 +99,10 @@ function parseTestMethods(
 
         if (TEST_ATTRIBUTE_REGEX.test(trimmed)) {
             nextMethodIsTest = true;
+        }
+
+        if (DYNAMIC_SOURCE_ATTRIBUTE_REGEX.test(trimmed)) {
+            nextMethodIsDynamicSource = true;
         }
 
         const paramArgs = extractParameterArgs(trimmed);
@@ -135,10 +142,12 @@ function parseTestMethods(
                         ...shared,
                         fullyQualifiedName: baseFqn,
                         displayName: methodName,
+                        hasDynamicSource: nextMethodIsDynamicSource || undefined,
                     });
                 }
 
                 nextMethodIsTest = false;
+                nextMethodIsDynamicSource = false;
                 pendingParams.length = 0;
             }
         }

--- a/src/discovery/patterns.ts
+++ b/src/discovery/patterns.ts
@@ -10,4 +10,7 @@ export const CLASS_REGEX =
 export const METHOD_REGEX =
     /(?:public|internal|protected)\s+(?:static\s+|async\s+|virtual\s+|override\s+)*\S+\s+(\w+)\s*(?:<[^>]+>\s*)?\(/;
 
+export const DYNAMIC_SOURCE_ATTRIBUTE_REGEX =
+    /\[\s*(?:NUnit\.Framework\.)?TestCaseSource\b/;
+
 export const NAMESPACE_REGEX = /^\s*namespace\s+([\w.]+)/;

--- a/src/execution/resultMatcher.ts
+++ b/src/execution/resultMatcher.ts
@@ -84,13 +84,29 @@ export function matchAndApplyResults(
             const hasParams = baseName !== tr.testName;
 
             if (hasParams) {
-                const parentBaseFqn = baseName;
-                const displayName = tr.testName.split('.').pop() ?? tr.testName;
-                const dynamicNode = treeProvider.addDynamicCaseNode(
-                    parentBaseFqn,
+                const paramPart = tr.testName.substring(baseName.length);
+                const shortMethod = baseName.split('.').pop() ?? baseName;
+                const displayName = shortMethod + paramPart;
+
+                let dynamicNode = treeProvider.addDynamicCaseNode(
+                    baseName,
                     tr.testName,
                     displayName,
                 );
+
+                if (!dynamicNode) {
+                    const parent = findParentBySuffix(baseName, methodNodes);
+                    if (parent) {
+                        const parentBase = parent.fqn.replace(/\(.*\)$/, '');
+                        const fullCaseFqn = parentBase + paramPart;
+                        dynamicNode = treeProvider.addDynamicCaseNode(
+                            parentBase,
+                            fullCaseFqn,
+                            displayName,
+                        );
+                    }
+                }
+
                 if (dynamicNode) {
                     applyResultState(dynamicNode, state, details, treeProvider);
                     matched = true;
@@ -125,6 +141,25 @@ export function matchAndApplyResults(
     logger.log(
         `Results: ${summary.passed} passed, ${summary.failed} failed, ${summary.skipped} skipped`,
     );
+}
+
+/**
+ * Finds a parent method node whose base FQN (params stripped) matches the given
+ * base name exactly or by suffix. Handles the case where TRX results use short
+ * names (e.g., "MethodName") while tree nodes store full FQNs
+ * (e.g., "Namespace.Class.MethodName").
+ */
+function findParentBySuffix(
+    baseName: string,
+    candidates: TestTreeNode[],
+): TestTreeNode | undefined {
+    for (const node of candidates) {
+        const nodeBase = node.fqn.replace(/\(.*\)$/, '');
+        if (nodeBase === baseName || nodeBase.endsWith(`.${baseName}`)) {
+            return node;
+        }
+    }
+    return undefined;
 }
 
 function tryMatchResult(

--- a/test/discovery/dotnetDiscoverer.test.ts
+++ b/test/discovery/dotnetDiscoverer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { extractParameterArgs } from '../../src/discovery/dotnetDiscoverer';
+import { DYNAMIC_SOURCE_ATTRIBUTE_REGEX } from '../../src/discovery/patterns';
 
 describe('extractParameterArgs', () => {
     it('should extract args from NUnit [TestCase(...)]', () => {
@@ -116,5 +117,41 @@ describe('extractParameterArgs', () => {
         const result = extractParameterArgs('');
 
         expect(result).toBeUndefined();
+    });
+});
+
+describe('DYNAMIC_SOURCE_ATTRIBUTE_REGEX', () => {
+    it('should match [TestCaseSource(...)]', () => {
+        expect(DYNAMIC_SOURCE_ATTRIBUTE_REGEX.test('[TestCaseSource(nameof(Cases))]')).toBe(true);
+    });
+
+    it('should match with NUnit.Framework prefix', () => {
+        expect(
+            DYNAMIC_SOURCE_ATTRIBUTE_REGEX.test('[NUnit.Framework.TestCaseSource(typeof(MySource))]'),
+        ).toBe(true);
+    });
+
+    it('should match with leading whitespace', () => {
+        expect(
+            DYNAMIC_SOURCE_ATTRIBUTE_REGEX.test('    [TestCaseSource(nameof(GetData))]'),
+        ).toBe(true);
+    });
+
+    it('should match with whitespace inside brackets', () => {
+        expect(
+            DYNAMIC_SOURCE_ATTRIBUTE_REGEX.test('[  TestCaseSource(nameof(Cases))]'),
+        ).toBe(true);
+    });
+
+    it('should not match [TestCase(...)]', () => {
+        expect(DYNAMIC_SOURCE_ATTRIBUTE_REGEX.test('[TestCase(1, 2)]')).toBe(false);
+    });
+
+    it('should not match [Test]', () => {
+        expect(DYNAMIC_SOURCE_ATTRIBUTE_REGEX.test('[Test]')).toBe(false);
+    });
+
+    it('should not match plain code', () => {
+        expect(DYNAMIC_SOURCE_ATTRIBUTE_REGEX.test('var x = TestCaseSource;')).toBe(false);
     });
 });

--- a/test/execution/resultMatcher.test.ts
+++ b/test/execution/resultMatcher.test.ts
@@ -49,6 +49,8 @@ vi.mock('vscode', () => {
 import { TestTreeProvider, TestTreeNode } from '../../src/ui/testTreeProvider';
 import { applyResultState, matchAndApplyResults } from '../../src/execution/resultMatcher';
 import type { TrxSummary } from '../../src/execution/trxParser';
+import type { DiscoveredTest } from '../../src/discovery/dotnetDiscoverer';
+import type { TestProject } from '../../src/discovery/projectDetector';
 import type { Logger } from '../../src/utils/logger';
 
 function createMockLogger(): Logger {
@@ -313,5 +315,198 @@ describe('matchAndApplyResults', () => {
         };
 
         expect(() => matchAndApplyResults(summary, [], treeProvider, mockLogger)).not.toThrow();
+    });
+});
+
+function makeProject(name: string, csprojPath: string): TestProject {
+    return {
+        projectName: name,
+        csprojPath,
+        projectDir: csprojPath.replace(/[/\\][^/\\]+$/, ''),
+    } as TestProject;
+}
+
+function makeTest(
+    ns: string,
+    cls: string,
+    method: string,
+    overrides: Partial<DiscoveredTest> = {},
+): DiscoveredTest {
+    return {
+        fullyQualifiedName: `${ns}.${cls}.${method}`,
+        namespace: ns,
+        className: cls,
+        methodName: method,
+        displayName: method,
+        sourceFile: `${cls}.cs`,
+        ...overrides,
+    } as DiscoveredTest;
+}
+
+function buildTreeWithTests(tests: DiscoveredTest[]): TestTreeProvider {
+    const provider = new TestTreeProvider();
+    const project = makeProject('TestProj', '/repo/TestProj/TestProj.csproj');
+    const testsByProject = new Map<string, DiscoveredTest[]>();
+    testsByProject.set(project.csprojPath, tests);
+    provider.buildTree([project], testsByProject);
+    return provider;
+}
+
+describe('matchAndApplyResults — TestCaseSource (dynamic cases)', () => {
+    let mockLogger: Logger;
+
+    beforeEach(() => {
+        mockLogger = createMockLogger();
+        vi.clearAllMocks();
+    });
+
+    it('should create dynamic case nodes when TRX uses FQN with params', () => {
+        const provider = buildTreeWithTests([
+            makeTest('NS', 'Cls', 'Add'),
+        ]);
+        const methodNodes = provider.getAllMethodNodes();
+        const summary: TrxSummary = {
+            total: 2,
+            passed: 2,
+            failed: 0,
+            skipped: 0,
+            duration: 100,
+            results: [
+                { testName: 'NS.Cls.Add(1,2,3)', outcome: 'Passed', duration: 50 },
+                { testName: 'NS.Cls.Add(4,5,9)', outcome: 'Passed', duration: 50 },
+            ],
+        };
+
+        matchAndApplyResults(summary, methodNodes, provider, mockLogger);
+
+        const methodNode = provider.getNodeByFqn('NS.Cls.Add');
+        expect(methodNode).toBeDefined();
+        expect(methodNode!.children).toHaveLength(2);
+        expect(methodNode!.children[0].nodeType).toBe('parameterizedCase');
+        expect(methodNode!.children[1].nodeType).toBe('parameterizedCase');
+        expect(methodNode!.children[0].state).toBe('passed');
+        expect(methodNode!.children[1].state).toBe('passed');
+    });
+
+    it('should create dynamic case nodes when TRX uses short names (no namespace)', () => {
+        const provider = buildTreeWithTests([
+            makeTest('MyNamespace', 'MyClass', 'Calculate'),
+        ]);
+        const methodNodes = provider.getAllMethodNodes();
+        const summary: TrxSummary = {
+            total: 2,
+            passed: 1,
+            failed: 1,
+            skipped: 0,
+            duration: 200,
+            results: [
+                { testName: 'Calculate(10,20,30)', outcome: 'Passed', duration: 100 },
+                { testName: 'Calculate(1,1,3)', outcome: 'Failed', errorMessage: 'Expected 3 but got 2', duration: 100 },
+            ],
+        };
+
+        matchAndApplyResults(summary, methodNodes, provider, mockLogger);
+
+        const methodNode = provider.getNodeByFqn('MyNamespace.MyClass.Calculate');
+        expect(methodNode).toBeDefined();
+        expect(methodNode!.children).toHaveLength(2);
+        expect(methodNode!.children[0].state).toBe('passed');
+        expect(methodNode!.children[1].state).toBe('failed');
+        expect(methodNode!.children[1].errorMessage).toBe('Expected 3 but got 2');
+    });
+
+    it('should propagate failed state to parent when any child fails', () => {
+        const provider = buildTreeWithTests([
+            makeTest('NS', 'Cls', 'Multiply'),
+        ]);
+        const methodNodes = provider.getAllMethodNodes();
+        const summary: TrxSummary = {
+            total: 3,
+            passed: 2,
+            failed: 1,
+            skipped: 0,
+            duration: 150,
+            results: [
+                { testName: 'NS.Cls.Multiply(2,3,6)', outcome: 'Passed', duration: 50 },
+                { testName: 'NS.Cls.Multiply(0,5,0)', outcome: 'Passed', duration: 50 },
+                { testName: 'NS.Cls.Multiply(-1,3,-4)', outcome: 'Failed', duration: 50 },
+            ],
+        };
+
+        matchAndApplyResults(summary, methodNodes, provider, mockLogger);
+
+        const methodNode = provider.getNodeByFqn('NS.Cls.Multiply');
+        expect(methodNode).toBeDefined();
+        expect(methodNode!.children).toHaveLength(3);
+        expect(methodNode!.state).toBe('failed');
+    });
+
+    it('should set display name correctly for dynamic case nodes', () => {
+        const provider = buildTreeWithTests([
+            makeTest('NS', 'Cls', 'Format'),
+        ]);
+        const methodNodes = provider.getAllMethodNodes();
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration: 50,
+            results: [
+                { testName: 'NS.Cls.Format("hello","world")', outcome: 'Passed', duration: 50 },
+            ],
+        };
+
+        matchAndApplyResults(summary, methodNodes, provider, mockLogger);
+
+        const methodNode = provider.getNodeByFqn('NS.Cls.Format');
+        expect(methodNode!.children).toHaveLength(1);
+        expect(methodNode!.children[0].label).toBe('Format("hello","world")');
+    });
+
+    it('should construct correct FQN for dynamic case nodes from short TRX names', () => {
+        const provider = buildTreeWithTests([
+            makeTest('App.Tests', 'MathTests', 'Add'),
+        ]);
+        const methodNodes = provider.getAllMethodNodes();
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration: 50,
+            results: [
+                { testName: 'Add(1,2,3)', outcome: 'Passed', duration: 50 },
+            ],
+        };
+
+        matchAndApplyResults(summary, methodNodes, provider, mockLogger);
+
+        const methodNode = provider.getNodeByFqn('App.Tests.MathTests.Add');
+        expect(methodNode!.children).toHaveLength(1);
+        expect(methodNode!.children[0].fqn).toBe('App.Tests.MathTests.Add(1,2,3)');
+    });
+
+    it('should not log unmatched for TestCaseSource results with short names', () => {
+        const provider = buildTreeWithTests([
+            makeTest('NS', 'Cls', 'Divide'),
+        ]);
+        const methodNodes = provider.getAllMethodNodes();
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration: 50,
+            results: [
+                { testName: 'Divide(10,2,5)', outcome: 'Passed', duration: 50 },
+            ],
+        };
+
+        matchAndApplyResults(summary, methodNodes, provider, mockLogger);
+
+        expect(mockLogger.log).not.toHaveBeenCalledWith(
+            expect.stringContaining('Unmatched result'),
+        );
     });
 });


### PR DESCRIPTION
## Summary
- Add suffix-based parent lookup in the result matcher so TRX results using short names (e.g. MethodName(1,2,3)) are correctly matched to tree nodes with full FQNs (e.g. Namespace.Class.MethodName), creating dynamic case child nodes under the parent method
- Fix displayName computation for dynamic case nodes to handle dots inside parameter values (e.g. string args containing periods)
- Add DYNAMIC_SOURCE_ATTRIBUTE_REGEX and hasDynamicSource flag to discovery so TestCaseSource methods are explicitly identified during static analysis

Closes #37

## Test plan
- [x] All 184 existing + new tests pass
- [ ] Verify TestCaseSource tests show pass/fail status after execution (manual)
- [ ] Verify dynamic case child nodes appear under the parent method in the tree
- [ ] Verify mixed pass/fail results propagate failed state to the parent node


Made with [Cursor](https://cursor.com)