### PR TITLE
test: verify multi-select test run results work correctly

### DIFF
--- a/test/execution/resultMatcher.test.ts
+++ b/test/execution/resultMatcher.test.ts
@@ -256,6 +256,54 @@ describe('matchAndApplyResults', () => {
         expect(node2.state).toBe('failed');
     });
 
+    it('should match results for tests selected from different classes', () => {
+        const nodeA = makeMethodNode('NS.ClassA.TestAlpha');
+        const nodeB = makeMethodNode('NS.ClassB.TestBeta');
+        const nodeC = makeMethodNode('NS.ClassC.TestGamma');
+        const summary: TrxSummary = {
+            total: 3,
+            passed: 2,
+            failed: 1,
+            skipped: 0,
+            duration: 450,
+            results: [
+                { testName: 'NS.ClassA.TestAlpha', outcome: 'Passed', duration: 100 },
+                { testName: 'NS.ClassB.TestBeta', outcome: 'Failed', errorMessage: 'assertion failed', duration: 200 },
+                { testName: 'NS.ClassC.TestGamma', outcome: 'Passed', duration: 150 },
+            ],
+        };
+
+        matchAndApplyResults(summary, [nodeA, nodeB, nodeC], treeProvider, mockLogger);
+
+        expect(nodeA.state).toBe('passed');
+        expect(nodeB.state).toBe('failed');
+        expect(nodeB.errorMessage).toBe('assertion failed');
+        expect(nodeC.state).toBe('passed');
+    });
+
+    it('should leave unmatched nodes unchanged when only a subset has results', () => {
+        const node1 = makeMethodNode('NS.Class.Test1');
+        const node2 = makeMethodNode('NS.Class.Test2');
+        const node3 = makeMethodNode('NS.Class.Test3');
+        const summary: TrxSummary = {
+            total: 2,
+            passed: 2,
+            failed: 0,
+            skipped: 0,
+            duration: 200,
+            results: [
+                { testName: 'NS.Class.Test1', outcome: 'Passed', duration: 100 },
+                { testName: 'NS.Class.Test3', outcome: 'Passed', duration: 100 },
+            ],
+        };
+
+        matchAndApplyResults(summary, [node1, node2, node3], treeProvider, mockLogger);
+
+        expect(node1.state).toBe('passed');
+        expect(node2.state).toBe('none');
+        expect(node3.state).toBe('passed');
+    });
+
     it('should match by suffix when TRX uses full FQN and node uses partial', () => {
         const node = makeMethodNode('Class.TestMethod');
         const summary: TrxSummary = {

--- a/test/execution/testRunner.test.ts
+++ b/test/execution/testRunner.test.ts
@@ -291,6 +291,62 @@ describe('collectAllMethodNodes', () => {
     });
 });
 
+describe('multi-select pipeline', () => {
+    it('should build filter and collect method nodes for cross-class multi-select', () => {
+        const projectPath = '/path/to/project.csproj';
+        const nodeA = makeNode('method', 'NS.ClassA.Test1', projectPath);
+        const nodeB = makeNode('method', 'NS.ClassB.Test2', projectPath);
+        const nodeC = makeNode('method', 'NS.ClassC.Test3', projectPath);
+        const selected = [nodeA, nodeB, nodeC];
+
+        const filter = buildFilterForNodes(selected);
+        const methodNodes = collectAllMethodNodes(selected);
+        const grouped = groupNodesByProject(selected);
+
+        expect(filter).toBe(
+            '(FullyQualifiedName~NS.ClassA.Test1) | (FullyQualifiedName~NS.ClassB.Test2) | (FullyQualifiedName~NS.ClassC.Test3)',
+        );
+        expect(methodNodes).toHaveLength(3);
+        expect(grouped.size).toBe(1);
+        expect(grouped.get(projectPath)).toHaveLength(3);
+    });
+
+    it('should build filter and group nodes for cross-project multi-select', () => {
+        const projA = '/path/to/projectA.csproj';
+        const projB = '/path/to/projectB.csproj';
+        const node1 = makeNode('method', 'NS.A.Test1', projA);
+        const node2 = makeNode('method', 'NS.B.Test2', projB);
+        const node3 = makeNode('method', 'NS.A.Test3', projA);
+
+        const grouped = groupNodesByProject([node1, node2, node3]);
+        const groupA = grouped.get(projA)!;
+        const groupB = grouped.get(projB)!;
+
+        expect(grouped.size).toBe(2);
+        expect(buildFilterForNodes(groupA)).toBe(
+            '(FullyQualifiedName~NS.A.Test1) | (FullyQualifiedName~NS.A.Test3)',
+        );
+        expect(buildFilterForNodes(groupB)).toBe('FullyQualifiedName~NS.B.Test2');
+        expect(collectAllMethodNodes(groupA)).toHaveLength(2);
+        expect(collectAllMethodNodes(groupB)).toHaveLength(1);
+    });
+
+    it('should handle mix of method and parameterizedCase nodes in multi-select', () => {
+        const projectPath = '/path/to/project.csproj';
+        const method = makeNode('method', 'NS.A.Test1', projectPath);
+        const case1 = makeNode('parameterizedCase', 'NS.B.Add(1,2)', projectPath);
+        const case2 = makeNode('parameterizedCase', 'NS.B.Add(3,4)', projectPath);
+
+        const filter = buildFilterForNodes([method, case1, case2]);
+        const methodNodes = collectAllMethodNodes([method, case1, case2]);
+
+        expect(filter).toBe(
+            '(FullyQualifiedName~NS.A.Test1) | (FullyQualifiedName=NS.B.Add(1,2)) | (FullyQualifiedName=NS.B.Add(3,4))',
+        );
+        expect(methodNodes).toHaveLength(3);
+    });
+});
+
 describe('groupNodesByProject', () => {
     it('should group nodes by project path', () => {
         const node1 = makeNode('method', 'NS.A.Test1', '/path/to/projectA.csproj');


### PR DESCRIPTION
## Summary
- Investigated issue #38 (multi-select run only shows result for first test) and confirmed the bug **does not exist** in the current codebase
- The multi-select execution pipeline (filter building, method node collection, project grouping, and result matching) was correctly implemented in PR #36 and further strengthened by the result matcher improvements in PR #40 (issue #37)
- Added 5 targeted tests to verify multi-select behavior across classes, projects, and mixed node types

Closes #38

## Test plan
- [x] All 189 tests pass (5 new, 184 existing)
- [x] Cross-class multi-select result matching verified
- [x] Cross-project filter building and grouping verified
- [x] Mixed method + parameterizedCase multi-select verified
- [x] Unmatched nodes correctly left unchanged

Made with [Cursor](https://cursor.com)