### PR TITLE
fix: prevent duplicate parameterized case nodes after test run

### DIFF
--- a/src/ui/testTreeProvider.ts
+++ b/src/ui/testTreeProvider.ts
@@ -325,7 +325,8 @@ export class TestTreeProvider implements vscode.TreeDataProvider<TestTreeNode> {
             return undefined;
         }
 
-        const existingCase = this.getNodeByFqn(caseFqn);
+        const existingCase =
+            this.getNodeByFqn(caseFqn) ?? this.findCaseByNormalizedFqn(caseFqn);
         if (existingCase) {
             return existingCase;
         }
@@ -352,6 +353,42 @@ export class TestTreeProvider implements vscode.TreeDataProvider<TestTreeNode> {
 
     getNodeById(id: string): TestTreeNode | undefined {
         return this.allNodes.get(id);
+    }
+
+    /**
+     * Searches for an existing parameterizedCase node whose FQN matches
+     * the given FQN after normalizing parameter whitespace and applying
+     * suffix matching. This prevents duplicate case nodes when the TRX
+     * result name differs from the discovered FQN only in formatting
+     * (e.g., "Add(1,2)" vs "Add(1, 2)").
+     */
+    private findCaseByNormalizedFqn(caseFqn: string): TestTreeNode | undefined {
+        const normalized = TestTreeProvider.normalizeParamWhitespace(caseFqn);
+        for (const [, node] of this.allNodes) {
+            if (node.nodeType !== 'parameterizedCase') {
+                continue;
+            }
+            const normalizedFqn = TestTreeProvider.normalizeParamWhitespace(node.fqn);
+            if (
+                normalizedFqn === normalized ||
+                normalizedFqn.endsWith(`.${normalized}`) ||
+                normalized.endsWith(`.${normalizedFqn}`)
+            ) {
+                return node;
+            }
+        }
+        return undefined;
+    }
+
+    private static normalizeParamWhitespace(name: string): string {
+        const parenIdx = name.indexOf('(');
+        if (parenIdx === -1) {
+            return name;
+        }
+        return (
+            name.substring(0, parenIdx) +
+            name.substring(parenIdx).replace(/,\s+/g, ',')
+        );
     }
 
     private subtreeMatchesFilter(node: TestTreeNode): boolean {

--- a/test/execution/resultMatcher.test.ts
+++ b/test/execution/resultMatcher.test.ts
@@ -558,3 +558,151 @@ describe('matchAndApplyResults — TestCaseSource (dynamic cases)', () => {
         );
     });
 });
+
+describe('matchAndApplyResults — TestCase duplicate prevention', () => {
+    let mockLogger: Logger;
+
+    beforeEach(() => {
+        mockLogger = createMockLogger();
+        vi.clearAllMocks();
+    });
+
+    it('should not duplicate discovered parameterized cases when TRX strips whitespace', () => {
+        const provider = buildTreeWithTests([
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(1, 2)',
+                displayName: 'Add(1, 2)',
+                parameters: '1, 2',
+            }),
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(3, 4)',
+                displayName: 'Add(3, 4)',
+                parameters: '3, 4',
+            }),
+        ]);
+        const methodNodes = provider.getAllMethodNodes();
+        const summary: TrxSummary = {
+            total: 2,
+            passed: 2,
+            failed: 0,
+            skipped: 0,
+            duration: 100,
+            results: [
+                { testName: 'Add(1,2)', outcome: 'Passed', duration: 50 },
+                { testName: 'Add(3,4)', outcome: 'Passed', duration: 50 },
+            ],
+        };
+
+        matchAndApplyResults(summary, methodNodes, provider, mockLogger);
+
+        const methodNode = provider.getNodeByFqn('NS.Cls.Add');
+        expect(methodNode).toBeDefined();
+        expect(methodNode!.children).toHaveLength(2);
+        expect(methodNode!.children[0].state).toBe('passed');
+        expect(methodNode!.children[1].state).toBe('passed');
+    });
+
+    it('should not duplicate cases when TRX uses FQN without spaces and source has spaces', () => {
+        const provider = buildTreeWithTests([
+            makeTest('NS', 'Cls', 'Calc', {
+                fullyQualifiedName: 'NS.Cls.Calc(1, 2, 3)',
+                displayName: 'Calc(1, 2, 3)',
+                parameters: '1, 2, 3',
+            }),
+        ]);
+        const methodNodes = provider.getAllMethodNodes();
+        const summary: TrxSummary = {
+            total: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration: 50,
+            results: [
+                { testName: 'NS.Cls.Calc(1,2,3)', outcome: 'Passed', duration: 50 },
+            ],
+        };
+
+        matchAndApplyResults(summary, methodNodes, provider, mockLogger);
+
+        const methodNode = provider.getNodeByFqn('NS.Cls.Calc');
+        expect(methodNode).toBeDefined();
+        expect(methodNode!.children).toHaveLength(1);
+        expect(methodNode!.children[0].state).toBe('passed');
+    });
+
+    it('should apply results to existing case nodes without creating duplicates (short TRX names)', () => {
+        const provider = buildTreeWithTests([
+            makeTest('App.Tests', 'MathTests', 'Add', {
+                fullyQualifiedName: 'App.Tests.MathTests.Add(1, 2)',
+                displayName: 'Add(1, 2)',
+                parameters: '1, 2',
+            }),
+            makeTest('App.Tests', 'MathTests', 'Add', {
+                fullyQualifiedName: 'App.Tests.MathTests.Add(3, 4)',
+                displayName: 'Add(3, 4)',
+                parameters: '3, 4',
+            }),
+        ]);
+
+        const caseNodes = provider.getAllMethodNodes().filter(
+            (n) => n.nodeType === 'parameterizedCase',
+        );
+        const summary: TrxSummary = {
+            total: 2,
+            passed: 1,
+            failed: 1,
+            skipped: 0,
+            duration: 200,
+            results: [
+                { testName: 'Add(1,2)', outcome: 'Passed', duration: 100 },
+                { testName: 'Add(3,4)', outcome: 'Failed', errorMessage: 'bad', duration: 100 },
+            ],
+        };
+
+        matchAndApplyResults(summary, caseNodes, provider, mockLogger);
+
+        const methodNode = provider.getNodeByFqn('App.Tests.MathTests.Add');
+        expect(methodNode).toBeDefined();
+        expect(methodNode!.children).toHaveLength(2);
+        expect(methodNode!.children[0].state).toBe('passed');
+        expect(methodNode!.children[1].state).toBe('failed');
+    });
+
+    it('should not duplicate when running from class level with mixed test types', () => {
+        const provider = buildTreeWithTests([
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(1, 2)',
+                displayName: 'Add(1, 2)',
+                parameters: '1, 2',
+            }),
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(3, 4)',
+                displayName: 'Add(3, 4)',
+                parameters: '3, 4',
+            }),
+            makeTest('NS', 'Cls', 'SimpleTest'),
+        ]);
+
+        const allLeafNodes = provider.getLeafTestNodes();
+        const summary: TrxSummary = {
+            total: 3,
+            passed: 3,
+            failed: 0,
+            skipped: 0,
+            duration: 150,
+            results: [
+                { testName: 'Add(1,2)', outcome: 'Passed', duration: 50 },
+                { testName: 'Add(3,4)', outcome: 'Passed', duration: 50 },
+                { testName: 'NS.Cls.SimpleTest', outcome: 'Passed', duration: 50 },
+            ],
+        };
+
+        matchAndApplyResults(summary, allLeafNodes, provider, mockLogger);
+
+        const methodNode = provider.getNodeByFqn('NS.Cls.Add');
+        expect(methodNode!.children).toHaveLength(2);
+
+        const simpleNode = provider.getNodeByFqn('NS.Cls.SimpleTest');
+        expect(simpleNode!.state).toBe('passed');
+    });
+});

--- a/test/ui/testTreeProvider.test.ts
+++ b/test/ui/testTreeProvider.test.ts
@@ -449,6 +449,60 @@ describe('TestTreeProvider.addDynamicCaseNode', () => {
 
         expect(result).toBeUndefined();
     });
+
+    it('should return existing node when FQN differs only in parameter whitespace', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(1, 2)',
+                displayName: 'Add(1, 2)',
+                parameters: '1, 2',
+            }),
+        ]);
+
+        const result = provider.addDynamicCaseNode('NS.Cls.Add', 'NS.Cls.Add(1,2)', 'Add(1,2)');
+
+        expect(result).toBeDefined();
+        expect(result?.fqn).toBe('NS.Cls.Add(1, 2)');
+    });
+
+    it('should return existing node when caseFqn is short name and existing has full FQN', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Add', {
+                fullyQualifiedName: 'NS.Cls.Add(1, 2)',
+                displayName: 'Add(1, 2)',
+                parameters: '1, 2',
+            }),
+        ]);
+
+        const result = provider.addDynamicCaseNode('NS.Cls.Add', 'Add(1,2)', 'Add(1,2)');
+
+        expect(result).toBeDefined();
+        expect(result?.fqn).toBe('NS.Cls.Add(1, 2)');
+    });
+
+    it('should not create duplicates for multiple params with whitespace differences', () => {
+        const provider = buildSingleProjectTree('Proj', [
+            makeTest('NS', 'Cls', 'Calc', {
+                fullyQualifiedName: 'NS.Cls.Calc(1, 2, 3)',
+                displayName: 'Calc(1, 2, 3)',
+                parameters: '1, 2, 3',
+            }),
+            makeTest('NS', 'Cls', 'Calc', {
+                fullyQualifiedName: 'NS.Cls.Calc(4, 5, 6)',
+                displayName: 'Calc(4, 5, 6)',
+                parameters: '4, 5, 6',
+            }),
+        ]);
+
+        const result1 = provider.addDynamicCaseNode('NS.Cls.Calc', 'NS.Cls.Calc(1,2,3)', 'Calc(1,2,3)');
+        const result2 = provider.addDynamicCaseNode('NS.Cls.Calc', 'NS.Cls.Calc(4,5,6)', 'Calc(4,5,6)');
+
+        expect(result1?.fqn).toBe('NS.Cls.Calc(1, 2, 3)');
+        expect(result2?.fqn).toBe('NS.Cls.Calc(4, 5, 6)');
+
+        const methodNode = provider.getNodeByFqn('NS.Cls.Calc');
+        expect(methodNode!.children).toHaveLength(2);
+    });
 });
 
 describe('TestTreeProvider.getNodeById', () => {


### PR DESCRIPTION
## Summary
- **Root cause**: ddDynamicCaseNode used exact string matching (getNodeByFqn) to check if a parameterized case node already existed. When the TRX result name differed from the discovered FQN in parameter whitespace (e.g., Add(1,2) vs Add(1, 2)), the check missed the existing node and created a duplicate.
- **Fix**: Added indCaseByNormalizedFqn — a normalized FQN lookup with suffix matching — as a fallback in ddDynamicCaseNode. This ensures existing case nodes are found even when parameter formatting differs between discovery (source code) and execution (TRX output).
- **Tests**: Added 7 new tests covering whitespace normalization, short-vs-full FQN matching, and end-to-end duplicate prevention scenarios.

Closes #45

## Test plan
- [ ] Verify all 200 tests pass (
px vitest run)
- [ ] Open a project with [TestCase] parameterized tests
- [ ] Run the tests and confirm each case appears exactly once with its result
- [ ] Run from class/namespace level and confirm no duplicates for parameterized cases
- [ ] Verify [TestCaseSource] dynamic tests still create case nodes correctly (no regression)


Made with [Cursor](https://cursor.com)