### PR TITLE
fix: quote dotnet test filter to prevent shell pipe interpretation

### DIFF
--- a/src/debug/debugLauncher.ts
+++ b/src/debug/debugLauncher.ts
@@ -39,7 +39,7 @@ export async function launchDebugSession(
 
     const filter = buildFilterForNode(node);
     if (filter) {
-        args.push('--filter', filter);
+        args.push('--filter', `"${filter}"`);
     }
 
     const extraArgs = getExtraArgs();

--- a/src/execution/testRunner.ts
+++ b/src/execution/testRunner.ts
@@ -216,7 +216,7 @@ async function executeTestRun(
     args.push('--results-directory', trxDir);
 
     if (filter) {
-        args.push('--filter', filter);
+        args.push('--filter', `"${filter}"`);
     }
 
     const extraArgs = getExtraArgs();


### PR DESCRIPTION
## Summary
- **Root cause:** `spawn` in `dotnetCli.ts` uses `shell: true`, so the `|` (OR) operator in multi-test filter expressions like `(FullyQualifiedName~Test1) | (FullyQualifiedName~Test2)` is interpreted by the shell as a pipe rather than passed literally to `dotnet test`
- **Fix:** Wrap the `--filter` value in double quotes in both `testRunner.ts` and `debugLauncher.ts` so the shell treats `|`, `(`, `)` as literal characters
- All 200 existing tests pass

Closes #46

## Test plan
- [ ] Multi-select 2+ tests from the same class and run — verify all show pass/fail results
- [ ] Multi-select tests from different classes and run — verify all show results
- [ ] Run a single test — verify it still works as before
- [ ] Run a parameterized test case — verify it still works with parentheses in the filter
- [ ] Run all tests — verify no regression

Made with [Cursor](https://cursor.com)