### PR TITLE
chore: add VSIX release workflow rule

### DIFF
--- a/.cursor/rules/vsix-release.mdc
+++ b/.cursor/rules/vsix-release.mdc
@@ -1,0 +1,40 @@
+---
+description: Workflow for building a new VSIX release version
+alwaysApply: true
+---
+
+# VSIX Release Workflow
+
+When asked to build a new VSIX version (or "create a release", "new version", "package vsix", etc.), follow these steps strictly.
+
+## 1. Merge the Release PR
+
+Find and merge the open release-please PR into `main`:
+
+```powershell
+gh pr list --label "autorelease: pending"
+gh pr merge <pr-number> --merge
+```
+
+If no release PR exists, stop and inform the user.
+
+## 2. Pull Latest Main
+
+```powershell
+git checkout main
+git pull origin main
+```
+
+## 3. Build the VSIX
+
+```powershell
+npm run package
+```
+
+This compiles the extension and outputs the `.vsix` file into the `releases/` folder.
+
+## 4. Confirm
+
+Report to the user:
+- The version number (from `package.json`).
+- The path to the generated `.vsix` file in `releases/`.


### PR DESCRIPTION
## Summary
- Add a new Cursor rule (.cursor/rules/vsix-release.mdc) that defines the workflow for building a new VSIX version.
- When triggered, the workflow merges the release-please PR, pulls latest main, and builds the VSIX into the eleases/ folder.

## Test plan
- [ ] Verify the rule is picked up by Cursor when asking to build a new VSIX version

Made with [Cursor](https://cursor.com)