### PR TITLE
fix: only add numeric suffix for fractional values, not plain integers

### DIFF
--- a/src/discovery/dotnetDiscoverer.ts
+++ b/src/discovery/dotnetDiscoverer.ts
@@ -220,11 +220,17 @@ export function parseMethodParamTypes(line: string): string[] {
     });
 }
 
-const NUMERIC_LITERAL = /^(-?\d+(?:\.\d+)?)[dDfFmMuUlL]{0,2}$/;
+const NUMERIC_LITERAL = /^(-?\d+(?:\.\d+)?)([dDfFmMuUlL]{0,2})$/;
 
 /**
  * Formats a single parameter value based on its declared C# type,
  * replicating NUnit's canonical test-name formatting.
+ *
+ * NUnit's suffix logic is driven by the runtime type of the TestCase argument:
+ *   - int literal (10)       → no suffix, even if param is decimal
+ *   - double literal (10.5)  → 'd' if param is decimal, 'f' if param is float
+ *   - explicit C# 'm' (10m) → 'd' (decimal literal)
+ *   - explicit C# 'f' (3f)  → 'f' (float literal)
  */
 export function formatParamValue(value: string, type: string): string {
     const v = value.trim();
@@ -238,12 +244,24 @@ export function formatParamValue(value: string, type: string): string {
 
     if (numMatch) {
         const numPart = numMatch[1];
-        if (lower === 'decimal') {
+        const sourceSuffix = numMatch[2].toLowerCase();
+
+        if (sourceSuffix === 'm') {
             return numPart + 'd';
         }
-        if (lower === 'float' || lower === 'single') {
+        if (sourceSuffix === 'f') {
             return numPart + 'f';
         }
+
+        if (numPart.includes('.')) {
+            if (lower === 'decimal') {
+                return numPart + 'd';
+            }
+            if (lower === 'float' || lower === 'single') {
+                return numPart + 'f';
+            }
+        }
+
         return numPart;
     }
 

--- a/test/discovery/dotnetDiscoverer.test.ts
+++ b/test/discovery/dotnetDiscoverer.test.ts
@@ -222,8 +222,8 @@ describe('formatParamValue', () => {
         expect(formatParamValue('10.5258', 'decimal')).toBe('10.5258d');
     });
 
-    it('should add d suffix for integer value with decimal type', () => {
-        expect(formatParamValue('10', 'decimal')).toBe('10d');
+    it('should not add d suffix for integer value with decimal type', () => {
+        expect(formatParamValue('10', 'decimal')).toBe('10');
     });
 
     it('should add d suffix for negative decimal', () => {
@@ -232,6 +232,20 @@ describe('formatParamValue', () => {
 
     it('should strip C# m suffix and add NUnit d suffix for decimal', () => {
         expect(formatParamValue('10.5258m', 'decimal')).toBe('10.5258d');
+    });
+
+    it('should convert explicit C# m suffix on integer to NUnit d', () => {
+        expect(formatParamValue('10m', 'decimal')).toBe('10d');
+    });
+
+    it('should not add suffix to plain integers even when param is decimal', () => {
+        expect(formatParamValue('10', 'decimal')).toBe('10');
+        expect(formatParamValue('100', 'decimal')).toBe('100');
+        expect(formatParamValue('-5', 'decimal')).toBe('-5');
+    });
+
+    it('should not add suffix to plain integers even when param is float', () => {
+        expect(formatParamValue('10', 'float')).toBe('10');
     });
 
     it('should add f suffix for float type', () => {


### PR DESCRIPTION
## Summary
- Fix ormatParamValue to only add d/ suffix when the value has a fractional part (decimal point) or an explicit C# type suffix (m, ). Plain integer literals like 10 no longer get a suffix even when the parameter type is decimal.
- NUnit's suffix behavior is driven by the runtime type of the TestCase argument: int literals stay as-is, double literals (with decimal point) get converted and suffixed.

Closes #60

## Test plan
- [x] All 261 tests pass
- [x] ormatParamValue('10', 'decimal') returns '10' (not '10d')
- [x] ormatParamValue('10.5258', 'decimal') still returns '10.5258d'
- [x] ormatParamValue('10m', 'decimal') returns '10d' (explicit C# decimal literal)
- [x] Plain integers with float param also get no suffix
