### PR TITLE
fix: handle multi-line method signatures when parsing parameter types

### DIFF
--- a/src/discovery/dotnetDiscoverer.ts
+++ b/src/discovery/dotnetDiscoverer.ts
@@ -130,7 +130,16 @@ function parseTestMethods(
                 };
 
                 if (pendingParams.length > 0) {
-                    const paramTypes = parseMethodParamTypes(trimmed);
+                    let signatureLine = trimmed;
+                    if (signatureLine.includes('(') && !signatureLine.includes(')')) {
+                        for (let j = i + 1; j < lines.length; j++) {
+                            signatureLine += ' ' + lines[j].trim();
+                            if (lines[j].includes(')')) {
+                                break;
+                            }
+                        }
+                    }
+                    const paramTypes = parseMethodParamTypes(signatureLine);
                     for (const params of pendingParams) {
                         const formatted = formatTestCaseParams(params, paramTypes);
                         results.push({

--- a/test/discovery/dotnetDiscoverer.test.ts
+++ b/test/discovery/dotnetDiscoverer.test.ts
@@ -215,6 +215,19 @@ describe('parseMethodParamTypes', () => {
 
         expect(parseMethodParamTypes(line)).toEqual(['float', 'long', 'double']);
     });
+
+    it('should parse concatenated multi-line signature', () => {
+        const line =
+            'public void Validate( decimal rate, decimal etoroPrice, int precision, bool isBuy = false)';
+
+        expect(parseMethodParamTypes(line)).toEqual(['decimal', 'decimal', 'int', 'bool']);
+    });
+
+    it('should handle default parameter values', () => {
+        const line = 'public void MyTest(decimal rate, bool isBuy = false)';
+
+        expect(parseMethodParamTypes(line)).toEqual(['decimal', 'bool']);
+    });
 });
 
 describe('formatParamValue', () => {


### PR DESCRIPTION
## Summary
- When a method signature spans multiple lines (common with many parameters), parseMethodParamTypes couldn't find the closing paren and returned empty, causing no type-based formatting. Discovery would show (6.5, 4, 2, true) instead of (6.5d, 4, 2, True).
- Fix: concatenate subsequent lines until the closing ) is found before parsing parameter types.

Closes #60

## Test plan
- [x] All 263 tests pass
- [x] New test for concatenated multi-line signature parsing
- [x] New test for signatures with default parameter values
