### PR TITLE
fix: strip named TestCase params (TestName, ExpectedResult) from positional args

### DIFF
--- a/src/discovery/dotnetDiscoverer.ts
+++ b/src/discovery/dotnetDiscoverer.ts
@@ -141,13 +141,27 @@ function parseTestMethods(
                     }
                     const paramTypes = parseMethodParamTypes(signatureLine);
                     for (const params of pendingParams) {
-                        const formatted = formatTestCaseParams(params, paramTypes);
-                        results.push({
-                            ...shared,
-                            fullyQualifiedName: `${baseFqn}(${formatted})`,
-                            displayName: `${methodName}(${formatted})`,
-                            parameters: formatted,
-                        });
+                        const parsed = parseTestCaseArgs(params);
+                        const formatted = formatTestCaseParams(
+                            parsed.positionalArgs,
+                            paramTypes,
+                        );
+
+                        if (parsed.testName) {
+                            results.push({
+                                ...shared,
+                                fullyQualifiedName: `${baseFqn}("${parsed.testName}")`,
+                                displayName: parsed.testName,
+                                parameters: formatted,
+                            });
+                        } else {
+                            results.push({
+                                ...shared,
+                                fullyQualifiedName: `${baseFqn}(${formatted})`,
+                                displayName: `${methodName}(${formatted})`,
+                                parameters: formatted,
+                            });
+                        }
                     }
                 } else {
                     results.push({
@@ -293,19 +307,50 @@ export function formatParamValue(value: string, type: string): string {
     return v;
 }
 
+interface ParsedTestCaseArgs {
+    positionalArgs: string[];
+    testName?: string;
+}
+
+const NAMED_PARAM = /^[A-Za-z_]\w*\s*=/;
+
+/**
+ * Separates positional parameter values from named attribute properties
+ * (TestName, ExpectedResult, Description, etc.) in a TestCase argument list.
+ */
+export function parseTestCaseArgs(rawArgs: string): ParsedTestCaseArgs {
+    const all = splitParams(rawArgs);
+    const positional: string[] = [];
+    let testName: string | undefined;
+
+    for (const param of all) {
+        const trimmed = param.trim();
+        if (NAMED_PARAM.test(trimmed)) {
+            const eqIdx = trimmed.indexOf('=');
+            const name = trimmed.substring(0, eqIdx).trim();
+            const value = trimmed.substring(eqIdx + 1).trim();
+            if (name === 'TestName') {
+                testName = value.replace(/^"(.*)"$/, '$1');
+            }
+            continue;
+        }
+        positional.push(trimmed);
+    }
+
+    return { positionalArgs: positional, testName };
+}
+
 /**
  * Formats all TestCase parameter values based on method parameter types
  * to produce the NUnit-canonical test name.
  * Falls back to raw whitespace-stripped params when types are unavailable.
  */
-function formatTestCaseParams(rawParams: string, paramTypes: string[]): string {
-    const values = splitParams(rawParams);
-
+function formatTestCaseParams(positionalArgs: string[], paramTypes: string[]): string {
     if (paramTypes.length === 0) {
-        return values.map((v) => v.trim()).join(',');
+        return positionalArgs.join(',');
     }
 
-    return values
+    return positionalArgs
         .map((val, i) => {
             const type = i < paramTypes.length ? paramTypes[i] : '';
             return formatParamValue(val, type);

--- a/test/discovery/dotnetDiscoverer.test.ts
+++ b/test/discovery/dotnetDiscoverer.test.ts
@@ -3,6 +3,7 @@ import {
     extractParameterArgs,
     parseMethodParamTypes,
     formatParamValue,
+    parseTestCaseArgs,
 } from '../../src/discovery/dotnetDiscoverer';
 import { DYNAMIC_SOURCE_ATTRIBUTE_REGEX } from '../../src/discovery/patterns';
 
@@ -340,5 +341,75 @@ describe('formatParamValue', () => {
 
     it('should leave simple enum member without prefix unchanged', () => {
         expect(formatParamValue('Active', 'MyEnum')).toBe('Active');
+    });
+});
+
+describe('parseTestCaseArgs', () => {
+    it('should return all args as positional when no named params', () => {
+        const result = parseTestCaseArgs('1, 2, 3');
+
+        expect(result.positionalArgs).toEqual(['1', '2', '3']);
+        expect(result.testName).toBeUndefined();
+    });
+
+    it('should strip TestName and extract its value', () => {
+        const result = parseTestCaseArgs(
+            '500, 10, -3, 10, -250, TestName = "Positive non margin amount"',
+        );
+
+        expect(result.positionalArgs).toEqual(['500', '10', '-3', '10', '-250']);
+        expect(result.testName).toBe('Positive non margin amount');
+    });
+
+    it('should strip ExpectedResult named param', () => {
+        const result = parseTestCaseArgs('1, 2, ExpectedResult = 3');
+
+        expect(result.positionalArgs).toEqual(['1', '2']);
+        expect(result.testName).toBeUndefined();
+    });
+
+    it('should strip Description named param', () => {
+        const result = parseTestCaseArgs('1, 2, Description = "my desc"');
+
+        expect(result.positionalArgs).toEqual(['1', '2']);
+    });
+
+    it('should handle TestName with special characters', () => {
+        const result = parseTestCaseArgs(
+            '500.4568, 10.5489, TestName = "Decimal parameters -> should round away from zero"',
+        );
+
+        expect(result.positionalArgs).toEqual(['500.4568', '10.5489']);
+        expect(result.testName).toBe(
+            'Decimal parameters -> should round away from zero',
+        );
+    });
+
+    it('should handle multiple named params', () => {
+        const result = parseTestCaseArgs(
+            '1, 2, TestName = "my test", Description = "some desc"',
+        );
+
+        expect(result.positionalArgs).toEqual(['1', '2']);
+        expect(result.testName).toBe('my test');
+    });
+
+    it('should handle TestName without spaces around equals', () => {
+        const result = parseTestCaseArgs('1, TestName="my test"');
+
+        expect(result.positionalArgs).toEqual(['1']);
+        expect(result.testName).toBe('my test');
+    });
+
+    it('should not treat negative numbers as named params', () => {
+        const result = parseTestCaseArgs('-1, -3.5, true');
+
+        expect(result.positionalArgs).toEqual(['-1', '-3.5', 'true']);
+    });
+
+    it('should not treat string literals as named params', () => {
+        const result = parseTestCaseArgs('"Name = value", 1');
+
+        expect(result.positionalArgs).toEqual(['"Name = value"', '1']);
     });
 });


### PR DESCRIPTION
## Summary
- NUnit [TestCase] attributes support named properties like TestName, ExpectedResult, Description, etc. These were being included as positional parameters, breaking type matching and polluting test names.
- Added parseTestCaseArgs() that separates positional values from named properties using the Identifier = value pattern.
- When TestName is present, it's used as the display name instead of the parameter-based name, matching NUnit's behavior.

Closes #60

## Test plan
- [x] All 272 tests pass
- [x] 9 new tests for parseTestCaseArgs covering: TestName extraction, ExpectedResult/Description stripping, multiple named params, special characters, no-space equals, negative numbers not misidentified, string literals not misidentified
