### PR TITLE
fix: use NUnit-canonical FQN for TestCase with TestName

### DIFF
--- a/src/discovery/dotnetDiscoverer.ts
+++ b/src/discovery/dotnetDiscoverer.ts
@@ -115,9 +115,10 @@ function parseTestMethods(
             const methodMatch = trimmed.match(METHOD_REGEX);
             if (methodMatch && currentClass) {
                 const methodName = methodMatch[1];
-                const baseFqn = currentNamespace
-                    ? `${currentNamespace}.${currentClass}.${methodName}`
-                    : `${currentClass}.${methodName}`;
+                const classFqn = currentNamespace
+                    ? `${currentNamespace}.${currentClass}`
+                    : currentClass;
+                const baseFqn = `${classFqn}.${methodName}`;
 
                 const shared = {
                     namespace: currentNamespace || currentClass,
@@ -150,7 +151,7 @@ function parseTestMethods(
                         if (parsed.testName) {
                             results.push({
                                 ...shared,
-                                fullyQualifiedName: `${baseFqn}("${parsed.testName}")`,
+                                fullyQualifiedName: `${classFqn}.${parsed.testName}`,
                                 displayName: parsed.testName,
                                 parameters: formatted,
                             });


### PR DESCRIPTION
## Summary
- When TestName is specified in [TestCase], NUnit uses Namespace.Class.TestNameValue as the FQN (no method name, no parens, no quotes).
- Previous code built FQN as aseFqn(

Made with [Cursor](https://cursor.com)TestNameValue) which produced invalid filter expressions causing 'No TRX results file generated' errors.

Closes #60

## Test plan
- [x] All 272 tests pass
- [x] TestCase with TestName param now produces correct FQN for dotnet filter
